### PR TITLE
Automatically deploy maps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+name: Deploy
+on:
+  push:
+    branches:
+    - master
+jobs:
+  deploy_maps:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -H "Authorization: token ${{ secrets.PRIVATE_GITHUB_ACCESS_TOKEN }}" \
+            -H 'Accept: application/vnd.github.everest-preview+json' \
+            "https://api.github.com/repos/graphhopper/architecture/dispatches" \
+            -d '{"event_type": "deploy", "client_payload": {}}'


### PR DESCRIPTION
This code will deploy the maps automatically. This will run a workflow in another repository that will do the actual deployment.

I've set up `PRIVATE_GITHUB_ACCESS_TOKEN` as a secret so this should work fine.

The deployment will be done for each merge/push to master. I've tested the functionality of this from my private test repository.