### PR TITLE
single click on map should not set a marker

### DIFF
--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -35,21 +35,6 @@ export default function ({ selectedPath, paths, queryPoints, bbox, mapStyle }: M
             () => {
                 setMap(mapWrapper)
                 Dispatcher.dispatch(new MapIsLoaded())
-            },
-            e => {
-                let point = queryPointsRef.current.find(point => !point.isInitialized)
-                if (!point) {
-                    point = queryPointsRef.current[0]
-                    Dispatcher.dispatch(new ClearPoints())
-                }
-                Dispatcher.dispatch(
-                    new SetPoint({
-                        ...point,
-                        isInitialized: true,
-                        coordinate: e.lngLat,
-                        queryText: e.lngLat.lng + ', ' + e.lngLat.lat,
-                    })
-                )
             }
         )
         mapWrapper.fitBounds(bbox)

--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -17,14 +17,7 @@ type MapProps = {
 
 export default function ({ selectedPath, paths, queryPoints, bbox, mapStyle }: MapProps) {
     const mapContainerRef: React.RefObject<HTMLDivElement> = useRef(null)
-    const queryPointsRef = useRef(queryPoints)
     const [map, setMap] = useState<Mapbox | null>(null)
-
-    // use this to be able to use querypoints props in onClick callback of the map
-    // see https://reactjs.org/docs/hooks-faq.html#what-can-i-do-if-my-effect-dependencies-change-too-often
-    useEffect(() => {
-        queryPointsRef.current = queryPoints
-    })
 
     useEffect(() => {
         if (map) map.remove()

--- a/src/map/Mapbox.ts
+++ b/src/map/Mapbox.ts
@@ -34,8 +34,7 @@ export default class Mapbox {
     constructor(
         container: HTMLDivElement,
         mapStyle: StyleOption,
-        onMapReady: () => void,
-        onClick: (e: MapMouseEvent) => void
+        onMapReady: () => void
     ) {
         this.map = new Map({
             container: container,
@@ -53,14 +52,11 @@ export default class Mapbox {
             onMapReady()
         })
 
-        this.map.on('click', onClick)
         this.map.on('contextmenu', e => this.popup.show(e.lngLat))
 
         // set up selection of alternative paths
-        // de-register default onClick handler when an alternative path is hovered
         this.map.on('mouseenter', pathsLayerKey, () => {
             this.map.getCanvasContainer().style.cursor = 'pointer'
-            this.map.off('click', onClick)
         })
 
         // select an alternative path if clicked
@@ -73,10 +69,9 @@ export default class Mapbox {
             }
         })
 
-        // re-register default click handler if mouse leaves alternative paths
+        // if mouse leaves alternative paths
         this.map.on('mouseleave', pathsLayerKey, () => {
             this.map.getCanvasContainer().style.cursor = ''
-            this.map.on('click', onClick)
         })
     }
 


### PR DESCRIPTION
This onClick behaviour is handy, but it often happens, especially on mobile, that the markers are changed due to accidentally clicking on the map

Should we revert the use of `useRef` as there is a comment:

> // use this to be able to use querypoints props in onClick callback of the map