### PR TITLE
avoid initial fitBounds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { getApiInfoStore, getErrorStore, getMapOptionsStore, getQueryStore, getR
 import MapComponent from '@/map/Map'
 import { Bbox } from '@/api/graphhopper'
 import MapOptions from '@/map/MapOptions'
+import { worldWideBBox } from '@/Converters'
 
 export default function App() {
     const [query, setQuery] = useState(getQueryStore().state)
@@ -41,7 +42,7 @@ export default function App() {
         if (shouldUseInfoBbox && pathBbox && pathBbox.every(num => num !== 0)) {
             setUseInfoBbox(false)
             return pathBbox
-        } else if (shouldUseInfoBbox) return infoBbox
+        } else if (shouldUseInfoBbox && !worldWideBBox(infoBbox)) return infoBbox
         return pathBbox || [0, 0, 0, 0]
     }
 

--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -1,3 +1,5 @@
+import { Bbox } from '@/api/graphhopper'
+
 export function milliSecondsToText(seconds: number) {
     const hours = Math.floor(seconds / 3600000)
     const minutes = Math.floor((seconds % 3600000) / 60000)
@@ -10,4 +12,8 @@ const distanceFormat = new Intl.NumberFormat(undefined, { maximumFractionDigits:
 export function metersToText(meters: number) {
     if (meters < 1000) return Math.floor(meters) + ' m'
     return distanceFormat.format(meters / 1000) + ' km'
+}
+
+export function worldWideBBox(bbox: Bbox): boolean {
+    return bbox[2] - bbox[0] > 359 && bbox[3] - bbox[1] > 179
 }

--- a/src/api/graphhopper.d.ts
+++ b/src/api/graphhopper.d.ts
@@ -1,5 +1,6 @@
 import { LineString } from 'geojson'
 
+// min lat, min lng, max lat, max lng
 export type Bbox = [number, number, number, number]
 
 export interface RoutingArgs {

--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -30,7 +30,7 @@ export default function ({ selectedPath, paths, queryPoints, bbox, mapStyle }: M
                 Dispatcher.dispatch(new MapIsLoaded())
             }
         )
-        mapWrapper.fitBounds(bbox)
+
         return () => map?.remove()
     }, [mapStyle])
     useEffect(() => map?.drawPaths(paths, selectedPath), [paths, selectedPath, map])

--- a/src/map/Mapbox.ts
+++ b/src/map/Mapbox.ts
@@ -38,9 +38,9 @@ export default class Mapbox {
     ) {
         this.map = new Map({
             container: container,
-            accessToken:
-                'pk.eyJ1IjoiamFuZWtkZXJlcnN0ZSIsImEiOiJjajd1ZDB6a3A0dnYwMnFtamx6eWJzYW16In0.9vY7vIQAoOuPj7rg1A_pfw',
+            accessToken: 'pk.eyJ1IjoiamFuZWtkZXJlcnN0ZSIsImEiOiJjajd1ZDB6a3A0dnYwMnFtamx6eWJzYW16In0.9vY7vIQAoOuPj7rg1A_pfw',
             style: Mapbox.getStyle(mapStyle),
+            /* bounds: new LngLatBounds(bbox) */
         })
 
         // add controls


### PR DESCRIPTION
this avoids the jump on load. the jump, when two points are specified, still exists.

TODO: zoom a bit into the world (if world boundary) to avoid seeing some continents twice.

related to #53