### PR TITLE
no error for empty profile

### DIFF
--- a/src/QueryUrl.ts
+++ b/src/QueryUrl.ts
@@ -45,14 +45,13 @@ function parsePoints(url: URL, queryPointsFromStore: QueryPoint[]) {
 }
 
 function parseRoutingProfile(url: URL) {
-    const profileKey = url.searchParams.get('profile')
-    if (profileKey) {
-        Dispatcher.dispatch(
-            new SetVehicleProfile({
-                key: profileKey
-            })
-        )
-    }
+    var profileKey = url.searchParams.get('profile')
+    if (!profileKey) profileKey = "car"
+    Dispatcher.dispatch(
+        new SetVehicleProfile({
+            key: profileKey
+        })
+    )
 }
 
 function parseNumber(value: string) {


### PR DESCRIPTION
The problem is that an empty `profile` parameter is sent to the API endpoint for an URL like:

https://graphhopper.com/maps2/?point=51.47212%2C5.970732&point=49.001769%2C15.804879

When using the `vehicle` parameter this was not a problem as in those cases we set `car` as default. But for profile we require a value