### PR TITLE
#32 autocomplete keyboard

### DIFF
--- a/src/sidebar/search/AddressInput.module.css
+++ b/src/sidebar/search/AddressInput.module.css
@@ -2,31 +2,14 @@
     position: relative;
 }
 
-@media (max-width: 44rem) {
-    .fullscreen {
-        position: fixed;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background-color: white;
-        z-index: 5;
-        padding: 0.5rem;
-    }
-
-    .fullscreen .btnClose {
-        display: block;
-    }
-
-}
-
 .btnClose {
     display: none;
 }
 
 .inputContainer {
-    display: flex;
-    gap: 0.5rem;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-gap: 0;
 }
 
 .input {
@@ -44,6 +27,39 @@
     box-sizing: border-box;
     width: 100%;
     background: white;
-    border: solid 1px lightgray;
     z-index: 1000;
+    border: solid 1px lightgray;
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.1);
+    border-radius: 0.2rem;
 }
+
+@media (max-width: 44rem) {
+    .fullscreen {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: white;
+        z-index: 5;
+        padding: 0.5rem;
+    }
+
+    .fullscreen .inputContainer {
+        grid-gap: 0.5rem;
+    }
+
+    .fullscreen .btnClose {
+        display: flex;
+        align-self: stretch;
+        justify-self: stretch;
+        align-items: center;
+    }
+
+    .fullscreen .popup {
+        position: static;
+        box-shadow: none;
+        border: none;
+    }
+}
+

--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -77,7 +77,6 @@ export default function AddressInput(props: AddressInputProps) {
                     onKeyDown={onKeypress}
                     onFocus={() => setFullscreen(true)}
                     onBlur={() => {
-                        console.log('on blur')
                         setFullscreen(false)
                         setGeocodingResults([])
                     }}

--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -34,7 +34,12 @@ export default function AddressInput(props: AddressInputProps) {
     const searchInput = useRef<HTMLInputElement>(null)
     const onKeypress = useCallback(
         (event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Escape') {
+                searchInput.current!.blur()
+                return
+            }
             if (geocodingResults.length === 0) return
+
             switch (event.key) {
                 case 'ArrowUp':
                     setHighlightedResult(i => calculateHighlightedIndex(geocodingResults.length, i, -1))

--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -112,13 +112,14 @@ function calculateHighlightedIndex(length: number, currentIndex: number, increme
 }
 
 /**
- * Tried for hours to make this work with a hook but failed. Now doing it the way I know...
+ * This could definitely be achieved with an effect. But after trying for a while I saved some money and wrote it the
+ * Way I know. If we hire an 10+ react developer, this should be changed.
  */
 class Geocoder {
     private requestId = 0
-    private timeout = new Timout(500)
-    private api = new ApiImpl()
-    private onSuccess: (hits: GeocodingHit[]) => void
+    private readonly timeout = new Timout(500)
+    private readonly api = new ApiImpl()
+    private readonly onSuccess: (hits: GeocodingHit[]) => void
 
     constructor(onSuccess: (hits: GeocodingHit[]) => void) {
         this.onSuccess = onSuccess
@@ -148,7 +149,7 @@ class Geocoder {
         return this.requestId
     }
 
-    private static filterDuplicates = function (hits: GeocodingHit[]) {
+    private static filterDuplicates(hits: GeocodingHit[]) {
         const set: Set<string> = new Set()
         return hits.filter(hit => {
             if (!set.has(hit.osm_id)) {
@@ -161,7 +162,7 @@ class Geocoder {
 }
 
 class Timout {
-    private delay: number
+    private readonly delay: number
     private handle: number = 0
 
     constructor(delay: number) {

--- a/src/sidebar/search/GeocodingResult.module.css
+++ b/src/sidebar/search/GeocodingResult.module.css
@@ -1,9 +1,15 @@
+.geocodingList {
+
+}
+
+.geocodingListItem:not(:last-child) {
+    border-bottom: 1px lightgray solid;
+}
+
 .selectableGeocodingEntry {
     display: block;
     width: 100%;
-
     border: none;
-    border-bottom: 1px lightgray solid;
     background: none;
     color: inherit;
     font: inherit;
@@ -13,11 +19,7 @@
     overflow: hidden;
 }
 
-.selectableGeocodingEntry:hover {
-    background-color: #ececec;
-}
-
-.highlightedGeocodingEntry {
+.highlightedGeocodingEntry, .selectableGeocodingEntry:hover {
     background-color: #ececec;
 }
 

--- a/src/sidebar/search/GeocodingResult.module.css
+++ b/src/sidebar/search/GeocodingResult.module.css
@@ -17,6 +17,10 @@
     background-color: #ececec;
 }
 
+.highlightedGeocodingEntry {
+    background-color: #ececec;
+}
+
 .selectableGeocodingEntry:active {
     background-color: #c6c6c6;
 }

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -12,7 +12,7 @@ export default function GeocodingResult({
     onSelectHit: (hit: GeocodingHit) => void
 }) {
     return (
-        <ul>
+        <ul className={styles.geocodingList}>
             {hits.map(hit => (
                 <GeocodingEntry
                     key={hit.osm_id}
@@ -38,7 +38,7 @@ const GeocodingEntry = ({
         ? styles.selectableGeocodingEntry + ' ' + styles.highlightedGeocodingEntry
         : styles.selectableGeocodingEntry
     return (
-        <li>
+        <li className={styles.geocodingListItem}>
             <button
                 className={className}
                 onClick={() => {

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -3,25 +3,51 @@ import styles from './GeocodingResult.module.css'
 import React from 'react'
 
 export default function GeocodingResult({
-                                            hits,
-                                            onSelectHit
-                                        }: {
+    hits,
+    highlightedHit,
+    onSelectHit,
+}: {
     hits: GeocodingHit[]
+    highlightedHit: GeocodingHit
     onSelectHit: (hit: GeocodingHit) => void
 }) {
     return (
         <ul>
             {hits.map(hit => (
-                <GeocodingEntry key={hit.osm_id} entry={hit} onSelectHit={onSelectHit} />
+                <GeocodingEntry
+                    key={hit.osm_id}
+                    entry={hit}
+                    isHighlighted={hit === highlightedHit}
+                    onSelectHit={onSelectHit}
+                />
             ))}
         </ul>
     )
 }
 
-const GeocodingEntry = ({ entry, onSelectHit }: { entry: GeocodingHit; onSelectHit: (hit: GeocodingHit) => void }) => {
+const GeocodingEntry = ({
+    entry,
+    isHighlighted,
+    onSelectHit,
+}: {
+    entry: GeocodingHit
+    isHighlighted: boolean
+    onSelectHit: (hit: GeocodingHit) => void
+}) => {
+    const className = isHighlighted
+        ? styles.selectableGeocodingEntry + ' ' + styles.highlightedGeocodingEntry
+        : styles.selectableGeocodingEntry
     return (
         <li>
-            <button className={styles.selectableGeocodingEntry} onClick={() => onSelectHit(entry)}>
+            <button
+                className={className}
+                onClick={() => {
+                    console.log('hit selected ' + entry.name)
+                    onSelectHit(entry)
+                }}
+                // prevent blur event for input textbox
+                onPointerDown={e => e.preventDefault()}
+            >
                 <div className={styles.geocodingEntry}>
                     <span className={styles.geocodingEntryMain}>{convertToMainText(entry)}</span>
                     <span>{convertToSecondaryText(entry)}</span>


### PR DESCRIPTION
fixes #32 
fixes #54 
fixes #69 

Overhauled the Address Input Component. 

- It should now be possible to use arrow keys to navigate the result list. 
- On Enter the currently selected element from the result list is selected or the first one if no arrow key was pressed before
- On small screens the fullscreen view can be left with Esc
- When the Text Input looses focus, the geocoding results are not shown anymore
- Added a debounce of 500ms. (Maybe that's too much?)