### PR TITLE
Use readable css module names for dev build

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,21 +1,48 @@
-const { merge } = require('webpack-merge')
+const { mergeWithRules, CustomizeRule } = require('webpack-merge')
 const path = require('path')
 
 const common = require('./webpack.common.js')
 
-const config = merge(common, {
+const develop = {
     mode: 'development',
     devtool: 'source-map',
     devServer: {
         contentBase: path.resolve(__dirname, 'dist'),
         https: false,
         port: 3000,
-        host: '0.0.0.0',
+        host: '0.0.0.0'
     },
-})
-
-config.module.rules[3].use[1].options.modules = {
-    localIdentName: '[path][name]__[local]'
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                exclude: path.resolve(__dirname, 'node_modules'),
+                use: [
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: {
+                                localIdentName: '[path][name]__[local]'
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
 }
 
-module.exports = config
+const mergePattern = {
+    module: {
+        rules: {
+            test: CustomizeRule.Match,
+            exclude: CustomizeRule.Match,
+            use: {
+                loader: CustomizeRule.Match,
+                options: CustomizeRule.Replace
+            }
+        }
+    }
+}
+
+module.exports = mergeWithRules(mergePattern)(common, develop)

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const common = require('./webpack.common.js')
 
-module.exports = merge(common, {
+const config = merge(common, {
     mode: 'development',
     devtool: 'source-map',
     devServer: {
@@ -13,3 +13,9 @@ module.exports = merge(common, {
         host: '0.0.0.0',
     },
 })
+
+config.module.rules[3].use[1].options.modules = {
+    localIdentName: '[path][name]__[local]'
+}
+
+module.exports = config


### PR DESCRIPTION
Fixes #73, the DOM now looks like this:

![image](https://user-images.githubusercontent.com/17603532/121061277-ec2f3900-c7c3-11eb-8ea7-1e6378e9d852.png)
