### PR TITLE
Do not ignore initial bbox

### DIFF
--- a/src/map/Mapbox.ts
+++ b/src/map/Mapbox.ts
@@ -318,14 +318,12 @@ export default class Mapbox {
     }
 
     fitBounds(bbox: Bbox) {
-        if (bbox.every(num => num !== 0)) {
-            this.map.fitBounds(new LngLatBounds(bbox), {
-                padding: Mapbox.getPadding(),
-                duration: 500,
-                animate: !this.isFirstBounds,
-            })
-            if (this.isFirstBounds) this.isFirstBounds = false
-        }
+        this.map.fitBounds(new LngLatBounds(bbox), {
+            padding: Mapbox.getPadding(),
+            duration: 500,
+            animate: !this.isFirstBounds,
+        })
+        if (this.isFirstBounds) this.isFirstBounds = false
     }
 
     getViewPort(): ViewPort {

--- a/src/stores/RouteStore.ts
+++ b/src/stores/RouteStore.ts
@@ -12,7 +12,7 @@ export interface RouteStoreState {
 export default class RouteStore extends Store<RouteStoreState> {
     private static getEmptyPath(): Path {
         return {
-            bbox: [0, 0, 0, 0],
+            bbox: undefined,
             instructions: [],
             points: {
                 coordinates: [],


### PR DESCRIPTION
When the map loads and the bounding box is not the entire world (e.g. when using a local GH server with a smaller server) the map should be focused to the bounding box of the available road network. However, without this fix the initial bounding box we get from /info is ignored.