### PR TITLE
Use pointer events instead of click event to select a geocoding entry

### DIFF
--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -6,6 +6,7 @@ import GeocodingResult from '@/sidebar/search/GeocodingResult'
 import styles from './AddressInput.module.css'
 import { ApiImpl } from '@/api/Api'
 import { getTranslation } from '@/translation/Translation'
+
 let tr = getTranslation()
 
 export interface AddressInputProps {
@@ -52,8 +53,9 @@ export default function AddressInput(props: AddressInputProps) {
                 case 'Enter':
                     // by default use the first result, otherwise the highlighted one
                     const index = highlightedResult >= 0 ? highlightedResult : 0
-                    props.onAddressSelected(geocodingResults[index])
+                    // it seems like the order of the following two statments is important...
                     searchInput.current!.blur()
+                    props.onAddressSelected(geocodingResults[index])
                     break
             }
         },
@@ -99,8 +101,9 @@ export default function AddressInput(props: AddressInputProps) {
                         hits={geocodingResults}
                         highlightedHit={geocodingResults[highlightedResult]}
                         onSelectHit={hit => {
-                            props.onAddressSelected(hit)
+                            // it seems like the order of the following two statments is important...
                             searchInput.current!.blur()
+                            props.onAddressSelected(hit)
                         }}
                     />
                 </div>
@@ -122,7 +125,7 @@ function calculateHighlightedIndex(length: number, currentIndex: number, increme
  */
 class Geocoder {
     private requestId = 0
-    private readonly timeout = new Timout(500)
+    private readonly timeout = new Timout(300)
     private readonly api = new ApiImpl()
     private readonly onSuccess: (hits: GeocodingHit[]) => void
 

--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -140,7 +140,7 @@ class Geocoder {
     async requestAsync(query: string) {
         const currentId = this.getNextId()
         this.timeout.cancel()
-        if (!query) return
+        if (!query || query.length < 2) return
 
         await this.timeout.wait()
         try {

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -41,18 +41,20 @@ const GeocodingEntry = ({
         : styles.selectableGeocodingEntry
     return (
         <li className={styles.geocodingListItem}>
-            {/* This uses pointer down, up and cancel events to make things work on touch devices. Using the click event would close the popup to quickly */}
+            {
             <button
                 className={className}
-                onPointerDown={e => {
-                    setWasCancelled(false)
+                onClick={() => {
+                    console.log('hit selected ' + entry.name)
+                    onSelectHit(entry)
+                }}
+                // Using the click event would close the popup to quickly, see #100
+                onTouchEnd={e => {
+                    onSelectHit(entry)
                     e.preventDefault()
                 }}
-                onPointerUp={e => {
-                    e.preventDefault()
-                    if (!wasCancelled) onSelectHit(entry)
-                }}
-                onPointerCancel={() => setWasCancelled(true)}
+                // prevent blur event for input textbox
+                onPointerDown={e => e.preventDefault()}
             >
                 <div className={styles.geocodingEntry}>
                     <span className={styles.geocodingEntryMain}>{convertToMainText(entry)}</span>

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -1,6 +1,6 @@
 import { GeocodingHit } from '@/api/graphhopper'
 import styles from './GeocodingResult.module.css'
-import React from 'react'
+import React, { useState } from 'react'
 
 export default function GeocodingResult({
     hits,
@@ -34,6 +34,8 @@ const GeocodingEntry = ({
     isHighlighted: boolean
     onSelectHit: (hit: GeocodingHit) => void
 }) => {
+    const [wasCancelled, setWasCancelled] = useState(false)
+
     const className = isHighlighted
         ? styles.selectableGeocodingEntry + ' ' + styles.highlightedGeocodingEntry
         : styles.selectableGeocodingEntry
@@ -41,12 +43,15 @@ const GeocodingEntry = ({
         <li className={styles.geocodingListItem}>
             <button
                 className={className}
-                onClick={() => {
-                    console.log('hit selected ' + entry.name)
-                    onSelectHit(entry)
-                }}
                 // prevent blur event for input textbox
-                onPointerDown={e => e.preventDefault()}
+                onPointerDown={e => {
+                    setWasCancelled(false)
+                    e.preventDefault()
+                }}
+                onPointerUp={() => {
+                    if (!wasCancelled) onSelectHit(entry)
+                }}
+                onPointerCancel={() => setWasCancelled(true)}
             >
                 <div className={styles.geocodingEntry}>
                     <span className={styles.geocodingEntryMain}>{convertToMainText(entry)}</span>

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -41,9 +41,11 @@ const GeocodingEntry = ({
         : styles.selectableGeocodingEntry
     return (
         <li className={styles.geocodingListItem}>
+            {/* This uses pointer down, up and cancel events to make things work on touch devices. Using the click event would close the popup to quickly */}
             <button
                 className={className}
-                // prevent blur event for input textbox
+                // handle the click event to avoid re-focusing of the address input text input
+                onClick={e => e.preventDefault()}
                 onPointerDown={e => {
                     setWasCancelled(false)
                     e.preventDefault()

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -1,6 +1,6 @@
 import { GeocodingHit } from '@/api/graphhopper'
 import styles from './GeocodingResult.module.css'
-import React, { useState } from 'react'
+import React from 'react'
 
 export default function GeocodingResult({
     hits,
@@ -34,14 +34,11 @@ const GeocodingEntry = ({
     isHighlighted: boolean
     onSelectHit: (hit: GeocodingHit) => void
 }) => {
-    const [wasCancelled, setWasCancelled] = useState(false)
-
     const className = isHighlighted
         ? styles.selectableGeocodingEntry + ' ' + styles.highlightedGeocodingEntry
         : styles.selectableGeocodingEntry
     return (
         <li className={styles.geocodingListItem}>
-            {
             <button
                 className={className}
                 onClick={() => {

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -41,11 +41,11 @@ const GeocodingEntry = ({
         <li className={styles.geocodingListItem}>
             <button
                 className={className}
-                onClick={() => {
-                    console.log('hit selected ' + entry.name)
-                    onSelectHit(entry)
-                }}
-                // Using the click event would close the popup to quickly, see #100
+                // using click events for mouse interaction to select an entry.
+                onClick={() => onSelectHit(entry)}
+                // On touch devices when listening for the click or pointerup event the next or last address input would
+                // be immediately selected after the 'onSelectHit' method was called. This can be prevented by listening
+                // for the touchend event separately.
                 onTouchEnd={e => {
                     onSelectHit(entry)
                     e.preventDefault()

--- a/src/sidebar/search/GeocodingResult.tsx
+++ b/src/sidebar/search/GeocodingResult.tsx
@@ -44,13 +44,12 @@ const GeocodingEntry = ({
             {/* This uses pointer down, up and cancel events to make things work on touch devices. Using the click event would close the popup to quickly */}
             <button
                 className={className}
-                // handle the click event to avoid re-focusing of the address input text input
-                onClick={e => e.preventDefault()}
                 onPointerDown={e => {
                     setWasCancelled(false)
                     e.preventDefault()
                 }}
-                onPointerUp={() => {
+                onPointerUp={e => {
+                    e.preventDefault()
                     if (!wasCancelled) onSelectHit(entry)
                 }}
                 onPointerCancel={() => setWasCancelled(true)}


### PR DESCRIPTION
also reduce debounce when typing to 300ms to make the geocoding search feel more responsive

fix #91

@easbar @karussell can you please test this on your devices? I got slightly strange behaviour when changing the order of the Address selected dispatch and the triggered blur on the text input. Just want to make sure this doesn't only accidentially works on my devices.