### PR TITLE
Use Tab to select adresses

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,6 +138,7 @@ function LargeScreenLayout({ query, route, bbox, error, mapOptions, info, pathDe
                             points={query.queryPoints}
                             routingProfiles={info.profiles}
                             selectedProfile={query.routingProfile}
+                            autofocus={true}
                         />
                     </div>
                     <div>{!error.isDismissed && <ErrorMessage error={error} />}</div>

--- a/src/sidebar/MobileSidebar.tsx
+++ b/src/sidebar/MobileSidebar.tsx
@@ -77,6 +77,7 @@ function SearchView(props: {
                 points={props.points}
                 routingProfiles={props.routingProfiles}
                 selectedProfile={props.selectedProfile}
+                autofocus={false}
             />
         </div>
     )

--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -49,6 +49,7 @@ export default function AddressInput(props: AddressInputProps) {
                     setHighlightedResult(i => calculateHighlightedIndex(geocodingResults.length, i, 1))
                     break
                 case 'Enter':
+                case 'Tab':
                     // by default use the first result, otherwise the highlighted one
                     const index = highlightedResult >= 0 ? highlightedResult : 0
                     // it seems like the order of the following two statments is important...
@@ -84,6 +85,7 @@ export default function AddressInput(props: AddressInputProps) {
                         setGeocodingResults([])
                     }}
                     value={text}
+                    autoFocus={props.autofocus}
                     placeholder={tr(
                         type == QueryPointType.From ? 'from_hint' : type == QueryPointType.To ? 'to_hint' : 'via_hint'
                     )}

--- a/src/sidebar/search/Search.tsx
+++ b/src/sidebar/search/Search.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Dispatcher from '@/stores/Dispatcher'
 import styles from '@/sidebar/search/Search.module.css'
-import { QueryPoint } from '@/stores/QueryStore'
+import { QueryPoint, QueryPointType } from '@/stores/QueryStore'
 import { AddPoint, ClearRoute, InvalidatePoint, RemovePoint, SetPoint } from '@/actions/Actions'
 import RoutingProfiles from '@/sidebar/search/RoutingProfiles'
 import RemoveIcon from '../times-solid.svg'
@@ -16,11 +16,14 @@ export default function Search({
     points,
     routingProfiles,
     selectedProfile,
+    autofocus,
 }: {
     points: QueryPoint[]
     routingProfiles: RoutingProfile[]
     selectedProfile: RoutingProfile
+    autofocus: boolean
 }) {
+    points.every(point => point.isInitialized)
     return (
         <div className={styles.searchBox}>
             {points.map(point => (
@@ -32,6 +35,7 @@ export default function Search({
                         Dispatcher.dispatch(new ClearRoute())
                         Dispatcher.dispatch(new InvalidatePoint(point))
                     }}
+                    autofocus={point.type === QueryPointType.From && autofocus}
                 />
             ))}
             <PlainButton
@@ -49,10 +53,12 @@ const SearchBox = ({
     point,
     onChange,
     deletable,
+    autofocus,
 }: {
     point: QueryPoint
     deletable: boolean
     onChange: (value: string) => void
+    autofocus: boolean
 }) => {
     return (
         <>
@@ -60,7 +66,7 @@ const SearchBox = ({
             <div className={styles.searchBoxInput}>
                 <AddressInput
                     point={point}
-                    autofocus={false}
+                    autofocus={autofocus}
                     onCancel={() => console.log('cancel')}
                     onAddressSelected={hit =>
                         Dispatcher.dispatch(


### PR DESCRIPTION
fix #54 .

This works slightly different than described in #54 now. I kept the tab order as is, so that the delete buttons next to the input fields are still accessible via tab. Please let me know how this works for you. 

http://gh-maps-react.s3-website.eu-central-1.amazonaws.com/54_tab_search