### PR TITLE
move api keys out of the source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 /dist/
 *~
+apikeys*.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'; export MapTilerApiKey='not required for testing'
+    - echo "$APIKEYSJS_CONTENT" > apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'
+    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'; export MapTilerApiKey='not required for testing'
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ global:
 
 script:
     - echo "$APIKEYS_CONTENT" > apikeys.js
+    - cat apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ global:
 
 script:
     - echo "$APIKEYS_CONTENT" > apikeys.js
-    - cat apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - echo "$APIKEYSJS_CONTENT" > apikeys.js
+    - echo "$APIKEYS_CONTENT" > apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ global:
     - travis encrypt AWS_ACCESS_KEY_ID=$S3_KEY_ID --add
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
-script: npm run build && npm run test
+script:
+    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'
+    - npm run build && npm run test
 
 # install awscli command line tool to sync files to s3
 before_deploy: pip install --user awscli

--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 # GraphHopper Maps
 
-This is a responsive UI for the [GraphHopper routing engine](https://github.com/graphhopper/graphhopper) rewritten from scratch. Soon it will replace the [jquery-based maps UI](https://github.com/graphhopper/graphhopper#graphhopper-maps).
+This is the UI for the [GraphHopper routing engine](https://github.com/graphhopper/graphhopper).
+It was rewritten from scratch and will replace the [jquery-based maps UI](https://github.com/graphhopper/graphhopper#graphhopper-maps).
 
 Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 
 Get started:
 
- * use your GraphHopper API key at src/api/Api.ts
-   or point it to your local GraphHopper server (change apiAddress in this file)
+ * create an apikeys.js file with the content:
+```
+module.exports = {
+       "graphhopper": "missing_api_key",
+       "maptiler": "missing_api_key",
+       "omniscale": "missing_api_key",
+       "thunderforest": "missing_api_key",
+       "kurviger": "missing_api_key",
+}
+```
+   replace at least your GraphHopper and MapTiler API key or point it to your local GraphHopper and OpenMapTiles servers (change apiAddress in src/api/Api.ts)
  * npm install
  * npm run serve
  * open browser at http://0.0.0.0:3000/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 Get started:
 
  * create an apikeys.js file with the content:
-```json
+```js
 module.exports = {
   "graphhopper": "missing_api_key",
   "maptiler": "missing_api_key",

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 Get started:
 
  * create an apikeys.js file with the content:
-```
+```json
 module.exports = {
-       "graphhopper": "missing_api_key",
-       "maptiler": "missing_api_key",
-       "omniscale": "missing_api_key",
-       "thunderforest": "missing_api_key",
-       "kurviger": "missing_api_key",
+  "graphhopper": "missing_api_key",
+  "maptiler": "missing_api_key",
+  "omniscale": "missing_api_key",
+  "thunderforest": "missing_api_key",
+  "kurviger": "missing_api_key"
 }
 ```
-   replace at least your GraphHopper and MapTiler API key or point it to your local GraphHopper and OpenMapTiles servers (change apiAddress in src/api/Api.ts)
+   replace at least your GraphHopper and MapTiler API key. Instead of API keys you can
+also host the GraphHopper and OpenMapTiles servers on your own servers - see src/api/Api.ts
  * npm install
  * npm run serve
  * open browser at http://0.0.0.0:3000/

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -32,7 +32,7 @@ export default interface Api {
     geocode(query: string): Promise<GeocodingResult>
 }
 
-export const ghKey = process.env.GraphHopperApiKey ? process.env.GraphHopperApiKey.toString() : 'missing api key'
+export const ghKey = process.env.GraphHopperApiKey ? process.env.GraphHopperApiKey.toString() : 'missing_api_key'
 
 export class ApiImpl implements Api {
     private readonly apiKey: string

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -32,7 +32,7 @@ export default interface Api {
     geocode(query: string): Promise<GeocodingResult>
 }
 
-export const ghKey = 'fb45b8b2-fdda-4093-ac1a-8b57b4e50add'
+export const ghKey = process.env.GraphHopperApiKey ? process.env.GraphHopperApiKey.toString() : 'missing api key'
 
 export class ApiImpl implements Api {
     private readonly apiKey: string

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -2,10 +2,11 @@ import Store from '@/stores/Store'
 import { Action } from '@/stores/Dispatcher'
 import { MapIsLoaded, SelectMapStyle } from '@/actions/Actions'
 
-const osApiKey = 'mapsgraph-bf48cc0b'
-const mapTilerKey = '?key=wYonyRi2hNgJVH2qgs81'
-const thunderforestApiKey = '?apikey=95b7c76e19c04e36ab9756f2cdf15b32'
-const kurvigerApiKey = '?key=b582abd4-d55d-4cb1-8f34-f4254cd52aa7'
+const osApiKey = process.env.OmniscaleApiKey
+const mapTilerKey = process.env.MapTilerApiKey
+const thunderforestApiKey = process.env.ThunderforestApiKey
+const kurvigerApiKey = process.env.KurvigerApiKey
+
 const osmAttribution =
     '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'
 
@@ -38,7 +39,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
         const defaultStyle: VectorStyle = {
             name: 'MapTiler',
             type: 'vector',
-            url: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json' + mapTilerKey,
+            url: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json?key=' + mapTilerKey,
             attribution:
                 osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
         }
@@ -49,7 +50,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                 {
                     name: 'MapTiler Satellite',
                     type: 'vector',
-                    url: 'https://api.maptiler.com/maps/hybrid/style.json' + mapTilerKey,
+                    url: 'https://api.maptiler.com/maps/hybrid/style.json?key=' + mapTilerKey,
                     attribution:
                         osmAttribution +
                         ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
@@ -86,9 +87,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Transport',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -98,9 +99,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Cycle',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -110,9 +111,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Outdoors',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -122,9 +123,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Atlas',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -134,15 +135,15 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'Kurviger Liberty',
                     type: 'raster',
                     url: [
-                        'https://a-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://a-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://b-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://b-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://c-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://c-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://d-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://d-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://e-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://e-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
                     ],
                     attribution:
@@ -152,7 +153,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                 {
                     name: 'Mapilion',
                     type: 'vector',
-                    url: 'https://tiles.mapilion.com/assets/osm-bright/style.json' + kurvigerApiKey,
+                    url: 'https://tiles.mapilion.com/assets/osm-bright/style.json?key=' + kurvigerApiKey,
                     attribution:
                         osmAttribution +
                         ', &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -20,7 +20,7 @@ if (!apikeys.graphhopper) {
     console.log('module.exports = ' + JSON.stringify(emptyApiKeys))
     process.exit(-1)
 } else {
-  //  console.log('module.exports = ' + JSON.stringify(apikeys))
+    console.log('module.exports = ' + JSON.stringify(apikeys))
 }
 
 module.exports = {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -17,10 +17,10 @@ if (!apikeys.graphhopper) {
 
     console.log('Missing apikeys.js file or missing graphhopper key inside this file. Get it from https://graphhopper.com/dashboard')
     console.log('Then create the file with:')
-    console.log('module.exports = ' + JSON.stringify(emptyApiKeys))
+    console.log('module.exports=' + JSON.stringify(emptyApiKeys))
     process.exit(-1)
 } else {
-    console.log('module.exports = ' + JSON.stringify(apikeys))
+    // console.log('module.exports=' + JSON.stringify(apikeys))
 }
 
 module.exports = {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,27 @@
 const path = require('path')
+const webpack = require('webpack')
+
 const HTMLWebpackPlugin = require('html-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
+
+const apikeys = require('./apikeys.js')
+
+if (!apikeys.graphhopper) {
+    const emptyApiKeys = {
+       "graphhopper": "missing api key",
+       "maptiler": "missing api key",
+       "omniscale": "missing api key",
+       "thunderforest": "missing api key",
+       "kurviger": "missing api key",
+    }
+
+    console.log('Missing apikeys.js file or missing graphhopper key inside this file. Get it from https://graphhopper.com/dashboard')
+    console.log('Then create the file with:')
+    console.log('module.exports = ' + JSON.stringify(emptyApiKeys))
+    process.exit(-1)
+} else {
+  //  console.log('module.exports = ' + JSON.stringify(apikeys))
+}
 
 module.exports = {
     entry: path.resolve(__dirname, 'src', 'index.tsx'),
@@ -66,6 +87,13 @@ module.exports = {
     plugins: [
         new HTMLWebpackPlugin({ template: path.resolve(__dirname, 'src/index.html') }),
         new FaviconsWebpackPlugin(path.resolve(__dirname, 'src/favicon.png')),
+        new webpack.EnvironmentPlugin({
+            GraphHopperApiKey: apikeys.graphhopper, // use no default to throw exception if missing
+            MapTilerApiKey: apikeys.maptiler, // use no default to throw exception if missing
+            OmniscaleApiKey: apikeys.omniscale,
+            ThunderforestApiKey: apikeys.thunderforest,
+            KurvigerApiKey: apikeys.kurviger,
+        })
     ],
 
     // When importing a module whose path matches one of the following, just

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,11 +8,11 @@ const apikeys = require('./apikeys.js')
 
 if (!apikeys.graphhopper) {
     const emptyApiKeys = {
-       "graphhopper": "missing api key",
-       "maptiler": "missing api key",
-       "omniscale": "missing api key",
-       "thunderforest": "missing api key",
-       "kurviger": "missing api key",
+       "graphhopper": "missing_api_key",
+       "maptiler": "missing_api_key",
+       "omniscale": "missing_api_key",
+       "thunderforest": "missing_api_key",
+       "kurviger": "missing_api_key",
     }
 
     console.log('Missing apikeys.js file or missing graphhopper key inside this file. Get it from https://graphhopper.com/dashboard')

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,7 +1,13 @@
 const { mergeWithRules, CustomizeRule } = require('webpack-merge')
+const webpack = require('webpack')
 const path = require('path')
 
 const common = require('./webpack.common.js')
+
+if (!process.env.GraphHopperApiKey) {
+    console.log('Missing environment variable: GraphHopperApiKey. Get one from https://graphhopper.com/dashboard')
+    process.exit(-1)
+}
 
 const develop = {
     mode: 'development',
@@ -12,6 +18,15 @@ const develop = {
         port: 3000,
         host: '0.0.0.0',
     },
+    plugins: [
+        new webpack.EnvironmentPlugin({
+            GraphHopperApiKey: undefined, // use no default to throw exception if missing
+            MapTilerApiKey: undefined, // use no default to throw exception if missing
+            OmniscaleApiKey: "missing api key",
+            ThunderforestApiKey: "missing api key",
+            KurvigerApiKey: "missing api key",
+        })
+    ],
     module: {
         rules: [
             {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,13 +1,7 @@
 const { mergeWithRules, CustomizeRule } = require('webpack-merge')
-const webpack = require('webpack')
 const path = require('path')
 
 const common = require('./webpack.common.js')
-
-if (!process.env.GraphHopperApiKey) {
-    console.log('Missing environment variable: GraphHopperApiKey. Get one from https://graphhopper.com/dashboard')
-    process.exit(-1)
-}
 
 const develop = {
     mode: 'development',
@@ -18,15 +12,6 @@ const develop = {
         port: 3000,
         host: '0.0.0.0',
     },
-    plugins: [
-        new webpack.EnvironmentPlugin({
-            GraphHopperApiKey: undefined, // use no default to throw exception if missing
-            MapTilerApiKey: undefined, // use no default to throw exception if missing
-            OmniscaleApiKey: "missing api key",
-            ThunderforestApiKey: "missing api key",
-            KurvigerApiKey: "missing api key",
-        })
-    ],
     module: {
         rules: [
             {


### PR DESCRIPTION
To avoid using our API keys in other applications I tried to externalize them using environmental variables.

This works through the EnvironmentPlugin which basically replaces any occurrence of `process.env.XY` with the content of XY plus the string quotation (i.e. JSON.stringify(XY)).

TODO:

 - [x] Is this the correct way to do this? I didn't find a different approach and e.g. deck gl seems to do this similarly. In old gh maps we used browserify-swap which I liked more, but made problems in the last months.
 - [x] hide the API key also in travis
 - [x] use a json file (or something not in git) in the webpack process to avoid setting up the variables everytime we start development (`npm run watch`). This would also allow simpler switching between development and production configs.
 - [x] explain this setup in readme