### PR TITLE
Move config to external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 /dist/
 *~
+apikeys*.js

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.iml
 /dist/
 *~
-apikeys*.js
+config-local.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'; export MapTilerApiKey='not required for testing'
+    - echo "$APIKEYSJS_CONTENT" > apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - echo "$APIKEYS_CONTENT" > apikeys.js
+    - echo "$APIKEYS_CONTENT" > config-local.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'
+    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'; export MapTilerApiKey='not required for testing'
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - echo "$APIKEYS_CONTENT" > config-local.js
+    - echo "$CONFIG_CONTENT" > config-local.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ global:
 
 script:
     - echo "$APIKEYS_CONTENT" > apikeys.js
+    - cat apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ global:
 
 script:
     - echo "$APIKEYS_CONTENT" > apikeys.js
-    - cat apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ global:
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
 script:
-    - echo "$APIKEYSJS_CONTENT" > apikeys.js
+    - echo "$APIKEYS_CONTENT" > apikeys.js
     - npm run build-debug && npm run test
 
 # install awscli command line tool to sync files to s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ global:
     - travis encrypt AWS_ACCESS_KEY_ID=$S3_KEY_ID --add
     - travis encrypt AWS_SECRET_ACCESS_KEY=$S3_KEY --add
 
-script: npm run build && npm run test
+script:
+    - export GraphHopperApiKey='fb45b8b2-fdda-4093-ac1a-8b57b4e50add'
+    - npm run build && npm run test
 
 # install awscli command line tool to sync files to s3
 before_deploy: pip install --user awscli

--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
 # GraphHopper Maps
 
-This is a responsive UI for the [GraphHopper routing engine](https://github.com/graphhopper/graphhopper) rewritten from scratch. Soon it will replace the [jquery-based maps UI](https://github.com/graphhopper/graphhopper#graphhopper-maps).
+This is the UI for the [GraphHopper routing engine](https://github.com/graphhopper/graphhopper).
+It was rewritten from scratch and will replace the [jquery-based maps UI](https://github.com/graphhopper/graphhopper#graphhopper-maps).
 
 Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 
 Get started:
 
- * use your GraphHopper API key at src/api/Api.ts
-   or point it to your local GraphHopper server (change apiAddress in this file)
+ * create an apikeys.js file with the content:
+```
+module.exports = {
+       "graphhopper": "missing_api_key",
+       "maptiler": "missing_api_key",
+       "omniscale": "missing_api_key",
+       "thunderforest": "missing_api_key",
+       "kurviger": "missing_api_key",
+}
+```
+   replace at least your GraphHopper and MapTiler API key or point it to your local GraphHopper and OpenMapTiles servers (change apiAddress in src/api/Api.ts)
  * npm install
  * npm run serve
  * open browser at http://0.0.0.0:3000/

--- a/README.md
+++ b/README.md
@@ -7,18 +7,9 @@ Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 
 Get started:
 
- * create an apikeys.js file with the content:
-```js
-module.exports = {
-  "graphhopper": "missing_api_key",
-  "maptiler": "missing_api_key",
-  "omniscale": "missing_api_key",
-  "thunderforest": "missing_api_key",
-  "kurviger": "missing_api_key"
-}
-```
-   replace at least your GraphHopper and MapTiler API key. Instead of API keys you can
-also host the GraphHopper and OpenMapTiles servers on your own servers - see src/api/Api.ts
+ * copy config.js to config-local.js and enter your GraphHopper API key for routing (get it at https://www.graphhopper.com)
+   and your MapTiler key for map tiles. You can also change the 'api' field and point it at your local GraphHopper server,
+   e.g. `api: http://localhost:8989/` and similarly you can host your own tiles using e.g. OpenMapTiles
  * npm install
  * npm run serve
  * open browser at http://0.0.0.0:3000/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 Get started:
 
  * create an apikeys.js file with the content:
-```json
+```js
 module.exports = {
   "graphhopper": "missing_api_key",
   "maptiler": "missing_api_key",

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 Get started:
 
  * copy config.js to config-local.js and enter your GraphHopper API key for routing (get it at https://www.graphhopper.com)
-   and your MapTiler key for map tiles. You can also change the 'api' field and point it at your local GraphHopper server,
-   e.g. `api: http://localhost:8989/` and similarly you can host your own tiles using e.g. OpenMapTiles
+   or change the 'api' field and point it at your local GraphHopper server, e.g. `api: http://localhost:8989/`.
+ * optional: setup api keys for the other tile providers, see MapOptionsStore.ts. you can also change the default tile layer in config-local.js
  * npm install
  * npm run serve
  * open browser at http://0.0.0.0:3000/

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ Try it at [graphhopper.com/maps2](https://graphhopper.com/maps2/).
 Get started:
 
  * create an apikeys.js file with the content:
-```
+```json
 module.exports = {
-       "graphhopper": "missing_api_key",
-       "maptiler": "missing_api_key",
-       "omniscale": "missing_api_key",
-       "thunderforest": "missing_api_key",
-       "kurviger": "missing_api_key",
+  "graphhopper": "missing_api_key",
+  "maptiler": "missing_api_key",
+  "omniscale": "missing_api_key",
+  "thunderforest": "missing_api_key",
+  "kurviger": "missing_api_key"
 }
 ```
-   replace at least your GraphHopper and MapTiler API key or point it to your local GraphHopper and OpenMapTiles servers (change apiAddress in src/api/Api.ts)
+   replace at least your GraphHopper and MapTiler API key. Instead of API keys you can
+also host the GraphHopper and OpenMapTiles servers on your own servers - see src/api/Api.ts
  * npm install
  * npm run serve
  * open browser at http://0.0.0.0:3000/

--- a/config.js
+++ b/config.js
@@ -2,7 +2,11 @@
  * Webpack will replace this file with config-local.js if it exists
  */
 export default {
+    // the url of the GraphHopper backend, either use graphhopper.com or point it to your own GH instance
     api: 'https://graphhopper.com/api/1/',
+    // the tile layer used by default, see MapOptionsStore.ts for all options
+    defaultTiles: 'OpenStreetMap',
+    // various api keys used for the GH backend and the different tile providers
     keys: {
         graphhopper: "missing_api_key",
         maptiler: "missing_api_key",

--- a/config.js
+++ b/config.js
@@ -1,0 +1,14 @@
+/**
+ * Webpack will replace this file with config-local.js if it exists
+ */
+export default {
+    api: 'https://graphhopper.com/api/1/',
+    keys: {
+        graphhopper: "missing_api_key",
+        maptiler: "missing_api_key",
+        omniscale: "missing_api_key",
+        thunderforest: "missing_api_key",
+        kurviger: "missing_api_key"
+    }
+}
+

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 /**
  * Webpack will replace this file with config-local.js if it exists
  */
-export default {
+module.exports = {
     // the url of the GraphHopper backend, either use graphhopper.com or point it to your own GH instance
     api: 'https://graphhopper.com/api/1/',
     // the tile layer used by default, see MapOptionsStore.ts for all options

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
-    moduleNameMapper: { '@/(.*)$': '<rootDir>/src/$1' },
+    moduleNameMapper: {
+        '@/(.*)$': '<rootDir>/src/$1',
+        'config': '<rootDir>/config.js'
+    }
 }

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -32,7 +32,7 @@ export default interface Api {
     geocode(query: string): Promise<GeocodingResult>
 }
 
-export const ghKey = process.env.GraphHopperApiKey ? process.env.GraphHopperApiKey.toString() : 'missing api key'
+export const ghKey = process.env.GraphHopperApiKey ? process.env.GraphHopperApiKey.toString() : 'missing_api_key'
 
 export class ApiImpl implements Api {
     private readonly apiKey: string

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -32,7 +32,7 @@ export default interface Api {
     geocode(query: string): Promise<GeocodingResult>
 }
 
-export const ghKey = 'fb45b8b2-fdda-4093-ac1a-8b57b4e50add'
+export const ghKey = process.env.GraphHopperApiKey ? process.env.GraphHopperApiKey.toString() : 'missing api key'
 
 export class ApiImpl implements Api {
     private readonly apiKey: string

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -15,6 +15,7 @@ import {
 } from '@/api/graphhopper'
 import { LineString } from 'geojson'
 import { tr } from '@/translation/Translation'
+import config from 'config'
 
 interface ApiProfile {
     name: string
@@ -32,15 +33,16 @@ export default interface Api {
     geocode(query: string): Promise<GeocodingResult>
 }
 
-export const ghKey = process.env.GraphHopperApiKey ? process.env.GraphHopperApiKey.toString() : 'missing_api_key'
+export const ghKey = config.keys.graphhopper
+export const ghApi = config.api
 
 export class ApiImpl implements Api {
     private readonly apiKey: string
     private readonly apiAddress: string
 
-    constructor(apiKey = ghKey, apiAddress = 'https://graphhopper.com/api/1/') {
-        this.apiKey = apiKey
-        this.apiAddress = apiAddress
+    constructor() {
+        this.apiKey = ghKey
+        this.apiAddress = ghApi
     }
 
     async info(): Promise<ApiInfo> {

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -5,6 +5,7 @@ declare module 'leaflet.heightgraph/src/heightgraph'
 
 declare module 'config' {
     const api : string
+    const defaultTiles: string
     const keys = {
         graphhopper: string,
         omniscale: string,

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -3,6 +3,16 @@ declare module '*.svg'
 declare module '*.png'
 declare module 'leaflet.heightgraph/src/heightgraph'
 
+declare module 'config' {
+    const api : string
+    const keys = {
+        graphhopper: string,
+        omniscale: string,
+        maptiler: string,
+        thunderforest: string,
+        kurviger: string
+    }
+}
 declare module 'react-responsive' {
     function useMediaQuery(props: { query: string }): boolean
 }

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -1,11 +1,12 @@
 import Store from '@/stores/Store'
 import { Action } from '@/stores/Dispatcher'
 import { MapIsLoaded, SelectMapStyle } from '@/actions/Actions'
+import config from 'config'
 
-const osApiKey = process.env.OmniscaleApiKey
-const mapTilerKey = process.env.MapTilerApiKey
-const thunderforestApiKey = process.env.ThunderforestApiKey
-const kurvigerApiKey = process.env.KurvigerApiKey
+const osApiKey = config.keys.omniscale
+const mapTilerKey = config.keys.maptiler
+const thunderforestApiKey = config.keys.thunderforest
+const kurvigerApiKey = config.keys.kurviger
 
 const osmAttribution =
     '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -2,10 +2,11 @@ import Store from '@/stores/Store'
 import { Action } from '@/stores/Dispatcher'
 import { MapIsLoaded, SelectMapStyle } from '@/actions/Actions'
 
-const osApiKey = 'mapsgraph-bf48cc0b'
-const mapTilerKey = '?key=wYonyRi2hNgJVH2qgs81'
-const thunderforestApiKey = '?apikey=95b7c76e19c04e36ab9756f2cdf15b32'
-const kurvigerApiKey = '?key=b582abd4-d55d-4cb1-8f34-f4254cd52aa7'
+const osApiKey = process.env.OmniscaleApiKey
+const mapTilerKey = process.env.MapTilerApiKey
+const thunderforestApiKey = process.env.ThunderforestApiKey
+const kurvigerApiKey = process.env.KurvigerApiKey
+
 const osmAttribution =
     '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'
 
@@ -38,7 +39,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
         const defaultStyle: VectorStyle = {
             name: 'MapTiler',
             type: 'vector',
-            url: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json' + mapTilerKey,
+            url: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json?key=' + mapTilerKey,
             attribution:
                 osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
         }
@@ -49,7 +50,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                 {
                     name: 'MapTiler Satellite',
                     type: 'vector',
-                    url: 'https://api.maptiler.com/maps/hybrid/style.json' + mapTilerKey,
+                    url: 'https://api.maptiler.com/maps/hybrid/style.json?key=' + mapTilerKey,
                     attribution:
                         osmAttribution +
                         ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
@@ -86,9 +87,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Transport',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -98,9 +99,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Cycle',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -110,9 +111,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Outdoors',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -122,9 +123,9 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'TF Atlas',
                     type: 'raster',
                     url: [
-                        'https://a.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png' + thunderforestApiKey,
+                        'https://a.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://b.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+                        'https://c.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
                     ],
                     attribution:
                         osmAttribution +
@@ -134,15 +135,15 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                     name: 'Kurviger Liberty',
                     type: 'raster',
                     url: [
-                        'https://a-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://a-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://b-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://b-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://c-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://c-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://d-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://d-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
-                        'https://e-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png' +
+                        'https://e-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
                             kurvigerApiKey,
                     ],
                     attribution:
@@ -152,7 +153,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                 {
                     name: 'Mapilion',
                     type: 'vector',
-                    url: 'https://tiles.mapilion.com/assets/osm-bright/style.json' + kurvigerApiKey,
+                    url: 'https://tiles.mapilion.com/assets/osm-bright/style.json?key=' + kurvigerApiKey,
                     attribution:
                         osmAttribution +
                         ', &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -35,169 +35,176 @@ export interface VectorStyle extends StyleOption {
     url: string
 }
 
+const mapTiler: VectorStyle = {
+    name: 'MapTiler',
+    type: 'vector',
+    url: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json?key=' + mapTilerKey,
+    attribution: osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
+}
+const mapTilerSatellite: VectorStyle = {
+    name: 'MapTiler Satellite',
+    type: 'vector',
+    url: 'https://api.maptiler.com/maps/hybrid/style.json?key=' + mapTilerKey,
+    attribution: osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
+}
+const osmOrg: RasterStyle = {
+    name: 'OpenStreetMap',
+    type: 'raster',
+    url: [
+        'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    ],
+    attribution: osmAttribution,
+}
+const omniscale: RasterStyle = {
+    name: 'Omniscale',
+    type: 'raster',
+    url: ['https://maps.omniscale.net/v2/' + osApiKey + '/style.default/{z}/{x}/{y}.png'],
+    attribution: osmAttribution + ', &copy; <a href="https://maps.omniscale.com/" target="_blank">Omniscale</a>',
+}
+const esriSatellite: RasterStyle = {
+    name: 'Esri Satellite',
+    type: 'raster',
+    url: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+    attribution:
+        '&copy; <a href="http://www.esri.com/" target="_blank">Esri</a>' +
+        ' i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+    maxZoom: 18,
+}
+const tfTransport: RasterStyle = {
+    name: 'TF Transport',
+    type: 'raster',
+    url: [
+        'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://b.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://c.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+    ],
+    attribution:
+        osmAttribution +
+        ', <a href="https://www.thunderforest.com/maps/transport/" target="_blank">Thunderforest Transport</a>',
+}
+const tfCycle: RasterStyle = {
+    name: 'TF Cycle',
+    type: 'raster',
+    url: [
+        'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://b.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://c.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+    ],
+    attribution:
+        osmAttribution +
+        ', <a href="https://www.thunderforest.com/maps/opencyclemap/" target="_blank">Thunderforest Cycle</a>',
+}
+const tfOutdoors: RasterStyle = {
+    name: 'TF Outdoors',
+    type: 'raster',
+    url: [
+        'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://c.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+    ],
+    attribution:
+        osmAttribution +
+        ', <a href="https://www.thunderforest.com/maps/outdoors/" target="_blank">Thunderforest Outdoors</a>',
+}
+const tfAtlas: RasterStyle = {
+    name: 'TF Atlas',
+    type: 'raster',
+    url: [
+        'https://a.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://b.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+        'https://c.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
+    ],
+    attribution:
+        osmAttribution + ', <a href="https://thunderforest.com/maps/atlas/" target="_blank">Thunderforest Atlas</a>',
+}
+const kurviger: RasterStyle = {
+    name: 'Kurviger Liberty',
+    type: 'raster',
+    url: [
+        'https://a-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
+        'https://b-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
+        'https://c-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
+        'https://d-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
+        'https://e-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
+    ],
+    attribution:
+        osmAttribution +
+        ',&copy; <a href="https://kurviger.de/" target="_blank">Kurviger</a> &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',
+}
+const mapillion: VectorStyle = {
+    name: 'Mapilion',
+    type: 'vector',
+    url: 'https://tiles.mapilion.com/assets/osm-bright/style.json?key=' + kurvigerApiKey,
+    attribution:
+        osmAttribution +
+        ', &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',
+}
+const osmDe: RasterStyle = {
+    name: 'OpenStreetmap.de',
+    type: 'raster',
+    url: [
+        'https://a.tile.openstreetmap.de/{z}/{x}/{y}.png',
+        'https://b.tile.openstreetmap.de/{z}/{x}/{y}.png',
+        'https://c.tile.openstreetmap.de/{z}/{x}/{y}.png',
+    ],
+    attribution: osmAttribution,
+}
+const lyrk: RasterStyle = {
+    name: 'Lyrk',
+    type: 'raster',
+    url: ['https://tiles.lyrk.org/lr/{z}/{x}/{y}?apikey=6e8cfef737a140e2a58c8122aaa26077'],
+    attribution: osmAttribution + ', <a href="https://geodienste.lyrk.de/">Lyrk</a>',
+}
+const wanderreitkarte: RasterStyle = {
+    name: 'WanderReitKarte',
+    type: 'raster',
+    url: [
+        'https://topo.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
+        'https://topo2.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
+        'https://topo3.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
+        'https://topo4.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
+    ],
+    attribution: osmAttribution + ', <a href="https://wanderreitkarte.de" target="_blank">WanderReitKarte</a>',
+}
+const sorbian: RasterStyle = {
+    name: 'Sorbian Language',
+    type: 'raster',
+    url: ['https://a.tile.openstreetmap.de/tilesbw/osmhrb/{z}/{x}/{y}.png'],
+    attribution: osmAttribution + ', <a href="https://www.alberding.eu/">&copy; Alberding GmbH, CC-BY-SA</a>',
+}
+
+const styleOptions: StyleOption[] = [
+    mapTiler,
+    mapTilerSatellite,
+    osmOrg,
+    omniscale,
+    esriSatellite,
+    tfTransport,
+    tfCycle,
+    tfOutdoors,
+    tfAtlas,
+    kurviger,
+    mapillion,
+    osmDe,
+    // The original client has these but those options yield cors errors with mapbox yields a cors error
+    // lyrk,
+    // wanderreitkarte,
+    // This works but is extremely slow with mapbox
+    // sorbian
+]
+
 export default class MapOptionsStore extends Store<MapOptionsStoreState> {
     protected getInitialState(): MapOptionsStoreState {
-        const defaultStyle: VectorStyle = {
-            name: 'MapTiler',
-            type: 'vector',
-            url: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json?key=' + mapTilerKey,
-            attribution:
-                osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
-        }
+        const selectedStyle = styleOptions.find(s => s.name === config.defaultTiles)
+        if (!selectedStyle)
+            console.warn(
+                `Could not find tile layer specified in config: '${config.defaultTiles}', using default instead`
+            )
         return {
-            selectedStyle: defaultStyle,
-            styleOptions: [
-                defaultStyle,
-                {
-                    name: 'MapTiler Satellite',
-                    type: 'vector',
-                    url: 'https://api.maptiler.com/maps/hybrid/style.json?key=' + mapTilerKey,
-                    attribution:
-                        osmAttribution +
-                        ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
-                },
-                {
-                    name: 'OpenStreetMap',
-                    type: 'raster',
-                    url: [
-                        'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                        'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                        'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                    ],
-                    attribution: osmAttribution,
-                },
-                {
-                    name: 'Omniscale',
-                    type: 'raster',
-                    url: ['https://maps.omniscale.net/v2/' + osApiKey + '/style.default/{z}/{x}/{y}.png'],
-                    attribution:
-                        osmAttribution + ', &copy; <a href="https://maps.omniscale.com/" target="_blank">Omniscale</a>',
-                },
-                {
-                    name: 'Esri Satellite',
-                    type: 'raster',
-                    url: [
-                        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-                    ],
-                    attribution:
-                        '&copy; <a href="http://www.esri.com/" target="_blank">Esri</a>' +
-                        ' i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
-                    maxZoom: 18,
-                },
-                {
-                    name: 'TF Transport',
-                    type: 'raster',
-                    url: [
-                        'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                    ],
-                    attribution:
-                        osmAttribution +
-                        ', <a href="https://www.thunderforest.com/maps/transport/" target="_blank">Thunderforest Transport</a>',
-                },
-                {
-                    name: 'TF Cycle',
-                    type: 'raster',
-                    url: [
-                        'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                    ],
-                    attribution:
-                        osmAttribution +
-                        ', <a href="https://www.thunderforest.com/maps/opencyclemap/" target="_blank">Thunderforest Cycle</a>',
-                },
-                {
-                    name: 'TF Outdoors',
-                    type: 'raster',
-                    url: [
-                        'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                    ],
-                    attribution:
-                        osmAttribution +
-                        ', <a href="https://www.thunderforest.com/maps/outdoors/" target="_blank">Thunderforest Outdoors</a>',
-                },
-                {
-                    name: 'TF Atlas',
-                    type: 'raster',
-                    url: [
-                        'https://a.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://b.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                        'https://c.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
-                    ],
-                    attribution:
-                        osmAttribution +
-                        ', <a href="https://thunderforest.com/maps/atlas/" target="_blank">Thunderforest Atlas</a>',
-                },
-                {
-                    name: 'Kurviger Liberty',
-                    type: 'raster',
-                    url: [
-                        'https://a-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
-                            kurvigerApiKey,
-                        'https://b-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
-                            kurvigerApiKey,
-                        'https://c-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
-                            kurvigerApiKey,
-                        'https://d-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
-                            kurvigerApiKey,
-                        'https://e-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' +
-                            kurvigerApiKey,
-                    ],
-                    attribution:
-                        osmAttribution +
-                        ',&copy; <a href="https://kurviger.de/" target="_blank">Kurviger</a> &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',
-                },
-                {
-                    name: 'Mapilion',
-                    type: 'vector',
-                    url: 'https://tiles.mapilion.com/assets/osm-bright/style.json?key=' + kurvigerApiKey,
-                    attribution:
-                        osmAttribution +
-                        ', &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',
-                },
-                {
-                    name: 'OpenStreetmap.de',
-                    type: 'raster',
-                    url: [
-                        'https://a.tile.openstreetmap.de/{z}/{x}/{y}.png',
-                        'https://b.tile.openstreetmap.de/{z}/{x}/{y}.png',
-                        'https://c.tile.openstreetmap.de/{z}/{x}/{y}.png',
-                    ],
-                    attribution: osmAttribution,
-                },
-                /* The original client has this but those options yield cors errors with mapbox yields a cors error
-                {
-                    name: 'Lyrk',
-                    type: 'raster',
-                    url: ['https://tiles.lyrk.org/lr/{z}/{x}/{y}?apikey=6e8cfef737a140e2a58c8122aaa26077'],
-                    attribution: osmAttribution + ', <a href="https://geodienste.lyrk.de/">Lyrk</a>',
-                },
-                {
-                    name: 'WanderReitKarte',
-                    type: 'raster',
-                    url: [
-                        'https://topo.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
-                        'https://topo2.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
-                        'https://topo3.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
-                        'https://topo4.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
-                    ],
-                    attribution:
-                        osmAttribution + ', <a href="https://wanderreitkarte.de" target="_blank">WanderReitKarte</a>',
-                },
-                */
-                /* this works but is extremely slow with mapbox
-                {
-                    name: 'Sorbian Language',
-                    type: 'raster',
-                    url: ['https://a.tile.openstreetmap.de/tilesbw/osmhrb/{z}/{x}/{y}.png'],
-                    attribution:
-                        osmAttribution + ', <a href="https://www.alberding.eu/">&copy; Alberding GmbH, CC-BY-SA</a>',
-                },*/
-            ],
+            selectedStyle: selectedStyle ? selectedStyle : mapTiler,
+            styleOptions,
             isMapLoaded: false,
         }
     }

--- a/test/routing/Api.test.ts
+++ b/test/routing/Api.test.ts
@@ -2,7 +2,7 @@ import fetchMock from 'jest-fetch-mock'
 import { ErrorAction, InfoReceived, RouteRequestFailed, RouteRequestSuccess } from '../../src/actions/Actions'
 import { setTranslation } from '../../src/translation/Translation'
 import Dispatcher, { Action } from '../../src/stores/Dispatcher'
-import { ApiImpl, ghKey } from '../../src/api/Api'
+import { ApiImpl, ghApi, ghKey } from '../../src/api/Api'
 import { ApiInfo, ErrorResponse, RoutingArgs, RoutingRequest } from '../../src/api/graphhopper'
 
 beforeAll(() => {
@@ -23,7 +23,7 @@ afterAll(() => fetchMock.disableMocks())
 
 describe('info api', () => {
     it('should query correct url and dispatch an InfoReceived action', async () => {
-        const expectedUrl = 'https://graphhopper.com/api/1/info?key=' + ghKey
+        const expectedUrl = ghApi + 'info?key=' + ghKey
         const expected: ApiInfo = {
             bbox: [0, 0, 0, 0],
             import_date: 'some_date1',
@@ -81,7 +81,7 @@ describe('route', () => {
         const mockedDispatcher = jest.spyOn(Dispatcher, 'dispatch')
 
         fetchMock.mockResponse(request => {
-            expect(request.url.toString()).toEqual('https://graphhopper.com/api/1/route?key=' + ghKey)
+            expect(request.url.toString()).toEqual(ghApi + 'route?key=' + ghKey)
             expect(request.method).toEqual('POST')
             expect(request.headers.get('Accept')).toEqual('application/json')
             expect(request.headers.get('Content-Type')).toEqual('application/json')

--- a/test/routing/Api.test.ts
+++ b/test/routing/Api.test.ts
@@ -1,6 +1,6 @@
 import fetchMock from 'jest-fetch-mock'
 import { ErrorAction, InfoReceived, RouteRequestFailed, RouteRequestSuccess } from '../../src/actions/Actions'
-import { setTranslation, getTranslation } from '../../src/translation/Translation'
+import { setTranslation} from '../../src/translation/Translation'
 
 import Dispatcher from '../../src/stores/Dispatcher'
 import { ApiImpl, ghApi, ghKey } from '../../src/api/Api'

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -20,7 +20,7 @@ if (!apikeys.graphhopper) {
     console.log('module.exports = ' + JSON.stringify(emptyApiKeys))
     process.exit(-1)
 } else {
-  //  console.log('module.exports = ' + JSON.stringify(apikeys))
+    console.log('module.exports = ' + JSON.stringify(apikeys))
 }
 
 module.exports = {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -17,10 +17,10 @@ if (!apikeys.graphhopper) {
 
     console.log('Missing apikeys.js file or missing graphhopper key inside this file. Get it from https://graphhopper.com/dashboard')
     console.log('Then create the file with:')
-    console.log('module.exports = ' + JSON.stringify(emptyApiKeys))
+    console.log('module.exports=' + JSON.stringify(emptyApiKeys))
     process.exit(-1)
 } else {
-    console.log('module.exports = ' + JSON.stringify(apikeys))
+    // console.log('module.exports=' + JSON.stringify(apikeys))
 }
 
 module.exports = {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,27 @@
 const path = require('path')
+const webpack = require('webpack')
+
 const HTMLWebpackPlugin = require('html-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
+
+const apikeys = require('./apikeys.js')
+
+if (!apikeys.graphhopper) {
+    const emptyApiKeys = {
+       "graphhopper": "missing api key",
+       "maptiler": "missing api key",
+       "omniscale": "missing api key",
+       "thunderforest": "missing api key",
+       "kurviger": "missing api key",
+    }
+
+    console.log('Missing apikeys.js file or missing graphhopper key inside this file. Get it from https://graphhopper.com/dashboard')
+    console.log('Then create the file with:')
+    console.log('module.exports = ' + JSON.stringify(emptyApiKeys))
+    process.exit(-1)
+} else {
+  //  console.log('module.exports = ' + JSON.stringify(apikeys))
+}
 
 module.exports = {
     entry: path.resolve(__dirname, 'src', 'index.tsx'),
@@ -66,6 +87,13 @@ module.exports = {
     plugins: [
         new HTMLWebpackPlugin({ template: path.resolve(__dirname, 'src/index.html') }),
         new FaviconsWebpackPlugin(path.resolve(__dirname, 'src/favicon.png')),
+        new webpack.EnvironmentPlugin({
+            GraphHopperApiKey: apikeys.graphhopper, // use no default to throw exception if missing
+            MapTilerApiKey: apikeys.maptiler, // use no default to throw exception if missing
+            OmniscaleApiKey: apikeys.omniscale,
+            ThunderforestApiKey: apikeys.thunderforest,
+            KurvigerApiKey: apikeys.kurviger,
+        })
     ],
 
     // When importing a module whose path matches one of the following, just

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,11 +8,11 @@ const apikeys = require('./apikeys.js')
 
 if (!apikeys.graphhopper) {
     const emptyApiKeys = {
-       "graphhopper": "missing api key",
-       "maptiler": "missing api key",
-       "omniscale": "missing api key",
-       "thunderforest": "missing api key",
-       "kurviger": "missing api key",
+       "graphhopper": "missing_api_key",
+       "maptiler": "missing_api_key",
+       "omniscale": "missing_api_key",
+       "thunderforest": "missing_api_key",
+       "kurviger": "missing_api_key",
     }
 
     console.log('Missing apikeys.js file or missing graphhopper key inside this file. Get it from https://graphhopper.com/dashboard')

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,26 +1,18 @@
 const path = require('path')
-const webpack = require('webpack')
+const fs = require('fs')
 
 const HTMLWebpackPlugin = require('html-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
 
-const apikeys = require('./apikeys.js')
-
-if (!apikeys.graphhopper) {
-    const emptyApiKeys = {
-       "graphhopper": "missing_api_key",
-       "maptiler": "missing_api_key",
-       "omniscale": "missing_api_key",
-       "thunderforest": "missing_api_key",
-       "kurviger": "missing_api_key",
-    }
-
-    console.log('Missing apikeys.js file or missing graphhopper key inside this file. Get it from https://graphhopper.com/dashboard')
-    console.log('Then create the file with:')
-    console.log('module.exports=' + JSON.stringify(emptyApiKeys))
-    process.exit(-1)
+const localConfig = path.resolve(__dirname, 'config-local.js')
+const defaultConfig = path.resolve(__dirname, 'config.js')
+let config
+if (fs.existsSync(localConfig)) {
+    config = localConfig
+} else if (fs.existsSync(defaultConfig)) {
+    config = defaultConfig
 } else {
-    // console.log('module.exports=' + JSON.stringify(apikeys))
+    throw `The config file is missing: ${defaultConfig}`
 }
 
 module.exports = {
@@ -30,7 +22,10 @@ module.exports = {
         filename: 'bundle.js',
     },
     resolve: {
-        alias: { '@': path.resolve(__dirname, 'src') },
+        alias: {
+            '@': path.resolve(__dirname, 'src'),
+            config$: config
+        },
         extensions: ['.ts', '.tsx', '.js', '.json', '.css', '.svg'],
     },
     module: {
@@ -87,13 +82,6 @@ module.exports = {
     plugins: [
         new HTMLWebpackPlugin({ template: path.resolve(__dirname, 'src/index.html') }),
         new FaviconsWebpackPlugin(path.resolve(__dirname, 'src/favicon.png')),
-        new webpack.EnvironmentPlugin({
-            GraphHopperApiKey: apikeys.graphhopper, // use no default to throw exception if missing
-            MapTilerApiKey: apikeys.maptiler, // use no default to throw exception if missing
-            OmniscaleApiKey: apikeys.omniscale,
-            ThunderforestApiKey: apikeys.thunderforest,
-            KurvigerApiKey: apikeys.kurviger,
-        })
     ],
 
     // When importing a module whose path matches one of the following, just

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,7 +1,13 @@
 const { mergeWithRules, CustomizeRule } = require('webpack-merge')
+const webpack = require('webpack')
 const path = require('path')
 
 const common = require('./webpack.common.js')
+
+if (!process.env.GraphHopperApiKey) {
+    console.log('Missing environment variable: GraphHopperApiKey. Get one from https://graphhopper.com/dashboard')
+    process.exit(-1)
+}
 
 const develop = {
     mode: 'development',
@@ -12,6 +18,15 @@ const develop = {
         port: 3000,
         host: '0.0.0.0',
     },
+    plugins: [
+        new webpack.EnvironmentPlugin({
+            GraphHopperApiKey: undefined, // use no default to throw exception if missing
+            MapTilerApiKey: undefined, // use no default to throw exception if missing
+            OmniscaleApiKey: "missing api key",
+            ThunderforestApiKey: "missing api key",
+            KurvigerApiKey: "missing api key",
+        })
+    ],
     module: {
         rules: [
             {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,13 +1,7 @@
 const { mergeWithRules, CustomizeRule } = require('webpack-merge')
-const webpack = require('webpack')
 const path = require('path')
 
 const common = require('./webpack.common.js')
-
-if (!process.env.GraphHopperApiKey) {
-    console.log('Missing environment variable: GraphHopperApiKey. Get one from https://graphhopper.com/dashboard')
-    process.exit(-1)
-}
 
 const develop = {
     mode: 'development',
@@ -18,15 +12,6 @@ const develop = {
         port: 3000,
         host: '0.0.0.0',
     },
-    plugins: [
-        new webpack.EnvironmentPlugin({
-            GraphHopperApiKey: undefined, // use no default to throw exception if missing
-            MapTilerApiKey: undefined, // use no default to throw exception if missing
-            OmniscaleApiKey: "missing api key",
-            ThunderforestApiKey: "missing api key",
-            KurvigerApiKey: "missing api key",
-        })
-    ],
     module: {
         rules: [
             {


### PR DESCRIPTION
After I tried #120 I also tried this myself and this is the result...

I think what we want is a config file that has all the configuration we want (api keys, but also host and maybe later a flag for 'enable mvt' etc.). But since we do not want to keep the api keys in VCS it has to be possible to replace the config file. I am now using webpack's resolve/alias feature which allows redirecting import statements to a given path, and this path can be set conditionally in the webpack config. The condition I use is the existence of a `config-local.js` file which is in `.gitignore`. If this file exists it will be included in the bundle by webpack. If it does not exist the default `config.js` file is used, which is included in VCS. Anywhere in our code we can import the config like `import config from 'config'` where `'config'` is an alias for whatever config file we include in the webpack configuration (it might be `config-local.js` or `config.js`).

So what this means for development is that unless we create a `config-local.js` file the default `config.js` file is used and we can setup our own api keys in `config-local.js`.