### PR TITLE
Show vector tile labels on top of the path layer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ export default function App() {
 
     const mapLayers: MapLayer[] = [
         createQueryPointsLayer(query.queryPoints),
-        createPathsLayer(route.selectedPath, route.routingResult.paths),
+        createPathsLayer(route.selectedPath, route.routingResult.paths, mapOptions.firstSymbolLayerId),
     ]
     if (!isSmallScreen) mapLayers.push(createPathDetailsLayer(pathDetails))
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ function LargeScreenLayout({ query, route, viewport, mapLayers, error, mapOption
                 {
                     <MapComponent
                         viewport={viewport}
-                        styleOption={mapOptions.selectedStyle}
+                        mapStyle={mapOptions.selectedMapStyle}
                         queryPoints={query.queryPoints}
                         mapLayers={mapLayers}
                     />
@@ -164,7 +164,7 @@ function SmallScreenLayout({ query, route, viewport, mapLayers, error, mapOption
                 <MapComponent
                     viewport={viewport}
                     queryPoints={query.queryPoints}
-                    styleOption={mapOptions.selectedStyle}
+                    mapStyle={mapOptions.selectedMapStyle}
                     mapLayers={mapLayers}
                 />
             </div>

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -1,7 +1,7 @@
 import { Action } from '@/stores/Dispatcher'
 import { Coordinate, QueryPoint } from '@/stores/QueryStore'
 import { ApiInfo, Bbox, Path, RoutingArgs, RoutingProfile, RoutingResult } from '@/api/graphhopper'
-import { StyleOption } from '@/stores/MapOptionsStore'
+import { MapboxStyle } from '@/stores/MapOptionsStore'
 import { PathDetailsPoint } from '@/stores/PathDetailsStore'
 import { ViewportStoreState } from '@/stores/ViewportStore'
 
@@ -98,11 +98,19 @@ export class SetSelectedPath implements Action {
 
 export class DismissLastError implements Action {}
 
-export class SelectMapStyle implements Action {
-    readonly styleOption: StyleOption
+export class MapStylesReceived implements Action {
+    readonly mapStyles: MapboxStyle[]
 
-    constructor(styleOption: StyleOption) {
-        this.styleOption = styleOption
+    constructor(mapStyles: MapboxStyle[]) {
+        this.mapStyles = mapStyles
+    }
+}
+
+export class SelectMapStyle implements Action {
+    readonly mapStyle: MapboxStyle
+
+    constructor(mapStyle: MapboxStyle) {
+        this.mapStyle = mapStyle
     }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ setTranslation(navigator.language)
 const api = new ApiImpl()
 const queryStore = new QueryStore(api)
 const routeStore = new RouteStore(queryStore)
+const mapOptionsStore = new MapOptionsStore()
 
 const smallScreenMediaQuery = window.matchMedia('(max-width: 44rem)')
 
@@ -38,7 +39,7 @@ setStores({
     routeStore: routeStore,
     infoStore: new ApiInfoStore(),
     errorStore: new ErrorStore(),
-    mapOptionsStore: new MapOptionsStore(),
+    mapOptionsStore: mapOptionsStore,
     pathDetailsStore: new PathDetailsStore(),
     viewportStore: new ViewportStore(routeStore, () => smallScreenMediaQuery.matches),
 })
@@ -52,6 +53,7 @@ Dispatcher.register(getMapOptionsStore())
 Dispatcher.register(getPathDetailsStore())
 Dispatcher.register(getViewportStore())
 
+mapOptionsStore.loadStyles() // load map styles immediately
 api.infoWithDispatch() // get infos about the api as soon as possible
 
 // hook up the navbar to the query store and vice versa

--- a/src/layers/PathsLayer.tsx
+++ b/src/layers/PathsLayer.tsx
@@ -9,7 +9,7 @@ import { MapLayer } from '@/layers/MapLayer'
 const pathsLayerKey = 'pathsLayer'
 const selectedPathLayerKey = 'selectedPathLayer'
 
-export default function (selectedPath: Path, paths: Path[]): MapLayer {
+export default function (selectedPath: Path, paths: Path[], firstSymbolLayerId: string | undefined): MapLayer {
     const currentPaths = paths
         .map((path, i) => {
             return {
@@ -30,14 +30,14 @@ export default function (selectedPath: Path, paths: Path[]): MapLayer {
         },
         layer: (
             <>
-                {createUnselectedPaths(currentPaths)}
-                {createSelectedPath(selectedPath)}
+                {createUnselectedPaths(currentPaths, firstSymbolLayerId)}
+                {createSelectedPath(selectedPath, firstSymbolLayerId)}
             </>
         ),
     }
 }
 
-function createSelectedPath(path: Path) {
+function createSelectedPath(path: Path, firstSymbolLayerId: string | undefined) {
     const featureCollection: FeatureCollection = {
         type: 'FeatureCollection',
         features: [
@@ -61,12 +61,13 @@ function createSelectedPath(path: Path) {
                     'line-color': '#275DAD',
                     'line-width': 8,
                 }}
+                beforeId={firstSymbolLayerId}
             />
         </Source>
     )
 }
 
-function createUnselectedPaths(indexPaths: { path: Path; index: number }[]) {
+function createUnselectedPaths(indexPaths: { path: Path; index: number }[], firstSymbolLayerId: string | undefined) {
     const featureCollection: FeatureCollection = {
         type: 'FeatureCollection',
         features: indexPaths.map(indexPath => {
@@ -93,6 +94,7 @@ function createUnselectedPaths(indexPaths: { path: Path; index: number }[]) {
                     'line-width': 6,
                     'line-opacity': 0.8,
                 }}
+                beforeId={firstSymbolLayerId}
             />
         </Source>
     )

--- a/src/map/MapOptions.tsx
+++ b/src/map/MapOptions.tsx
@@ -1,12 +1,10 @@
 import React, { useState } from 'react'
 import styles from './MapOptions.modules.css'
-import { MapOptionsStoreState, StyleOption } from '@/stores/MapOptionsStore'
+import { MapboxStyle, MapOptionsStoreState } from '@/stores/MapOptionsStore'
 import Dispatcher from '@/stores/Dispatcher'
 import { SelectMapStyle } from '@/actions/Actions'
 import PlainButton from '@/PlainButton'
 import LayerImg from './layer-group-solid.svg'
-
-export interface MapOptionsProps {}
 
 export default function (props: MapOptionsStoreState) {
     const [isOpen, setIsOpen] = useState(false)
@@ -38,27 +36,27 @@ const Options = function ({ storeState, notifyChanged }: OptionsProps) {
             className={styles.options}
             onChange={e => {
                 notifyChanged()
-                onChange(e.target as HTMLInputElement, storeState.styleOptions)
+                onChange(e.target as HTMLInputElement, storeState.mapStyles)
             }}
         >
-            {storeState.styleOptions.map(option => (
-                <div className={styles.option} key={option.name}>
+            {storeState.mapStyles.map(style => (
+                <div className={styles.option} key={style.name}>
                     <input
                         type="radio"
-                        id={option.name}
+                        id={style.name}
                         name="layer"
-                        value={option.name}
-                        defaultChecked={option === storeState.selectedStyle}
+                        value={style.name}
+                        defaultChecked={style === storeState.selectedMapStyle}
                         disabled={!storeState.isMapLoaded}
                     />
-                    <label htmlFor={option.name}>{option.name}</label>
+                    <label htmlFor={style.name}>{style.name}</label>
                 </div>
             ))}
         </div>
     )
 }
 
-function onChange(target: HTMLInputElement, options: StyleOption[]) {
+function onChange(target: HTMLInputElement, options: MapboxStyle[]) {
     const option = options.find(option => option.name === target.value)
 
     if (option) Dispatcher.dispatch(new SelectMapStyle(option))

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -14,6 +14,7 @@ const osmAttribution =
 export interface MapOptionsStoreState {
     mapStyles: MapboxStyle[]
     selectedMapStyle: MapboxStyle
+    firstSymbolLayerId?: string
     isMapLoaded: boolean
 }
 
@@ -21,8 +22,8 @@ export interface MapboxStyle {
     name: string
     style: {
         version: number
-        sources: object
-        layers: object[]
+        sources: any
+        layers: any[]
     }
 }
 
@@ -259,11 +260,13 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
                 ...state,
                 mapStyles: mapStyles,
                 selectedMapStyle: selectedMapStyle ? selectedMapStyle : mapStyles[0],
+                firstSymbolLayerId: selectedMapStyle ? getFirstSymbolLayer(selectedMapStyle) : undefined,
             }
         } else if (action instanceof SelectMapStyle) {
             return {
                 ...state,
                 selectedMapStyle: action.mapStyle,
+                firstSymbolLayerId: getFirstSymbolLayer(action.mapStyle),
             }
         } else if (action instanceof MapIsLoaded) {
             return {
@@ -273,4 +276,8 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
         }
         return state
     }
+}
+
+function getFirstSymbolLayer(mapStyle: MapboxStyle) {
+    return mapStyle.style.layers.find(l => l.type === 'symbol')?.id
 }

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -1,6 +1,6 @@
 import Store from '@/stores/Store'
-import { Action } from '@/stores/Dispatcher'
-import { MapIsLoaded, SelectMapStyle } from '@/actions/Actions'
+import Dispatcher, { Action } from '@/stores/Dispatcher'
+import { ErrorAction, MapIsLoaded, MapStylesReceived, SelectMapStyle } from '@/actions/Actions'
 import config from 'config'
 
 const osApiKey = config.keys.omniscale
@@ -12,70 +12,75 @@ const osmAttribution =
     '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'
 
 export interface MapOptionsStoreState {
-    styleOptions: StyleOption[]
-    selectedStyle: StyleOption
+    mapStyles: MapboxStyle[]
+    selectedMapStyle: MapboxStyle
     isMapLoaded: boolean
 }
 
-export interface StyleOption {
+export interface MapboxStyle {
     name: string
-    type: 'raster' | 'vector'
-    url: string[] | string
+    style: {
+        version: number
+        sources: object
+        layers: object[]
+    }
+}
+
+/**
+ * For vector styles we enter just a url pointing to the json file containing the style
+ */
+interface VectorStyleEntry {
+    name: string
+    styleUrl: string
+    // todo: we do not use this so far and sometimes it is already included in the loaded style anyway
+    attribution: string
+}
+
+/**
+ * For raster styles we need the urls of the tile servers and create the style ourselves
+ */
+interface RasterStyleEntry {
+    name: string
+    tiles: string[]
     attribution: string
     maxZoom?: number
 }
 
-export interface RasterStyle extends StyleOption {
-    type: 'raster'
-    url: string[]
-}
-
-export interface VectorStyle extends StyleOption {
-    type: 'vector'
-    url: string
-}
-
-const mapTiler: VectorStyle = {
+const mapTiler: VectorStyleEntry = {
     name: 'MapTiler',
-    type: 'vector',
-    url: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json?key=' + mapTilerKey,
+    styleUrl: 'https://api.maptiler.com/maps/1f566542-c726-4cc5-8f2d-2309b90083db/style.json?key=' + mapTilerKey,
     attribution: osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
 }
-const mapTilerSatellite: VectorStyle = {
+const mapTilerSatellite: VectorStyleEntry = {
     name: 'MapTiler Satellite',
-    type: 'vector',
-    url: 'https://api.maptiler.com/maps/hybrid/style.json?key=' + mapTilerKey,
+    styleUrl: 'https://api.maptiler.com/maps/hybrid/style.json?key=' + mapTilerKey,
     attribution: osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
 }
-const osmOrg: RasterStyle = {
+const osmOrg: RasterStyleEntry = {
     name: 'OpenStreetMap',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
         'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
         'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
     ],
     attribution: osmAttribution,
 }
-const omniscale: RasterStyle = {
+const omniscale: RasterStyleEntry = {
     name: 'Omniscale',
-    type: 'raster',
-    url: ['https://maps.omniscale.net/v2/' + osApiKey + '/style.default/{z}/{x}/{y}.png'],
+    tiles: ['https://maps.omniscale.net/v2/' + osApiKey + '/style.default/{z}/{x}/{y}.png'],
     attribution: osmAttribution + ', &copy; <a href="https://maps.omniscale.com/" target="_blank">Omniscale</a>',
 }
-const esriSatellite: RasterStyle = {
+const esriSatellite: RasterStyleEntry = {
     name: 'Esri Satellite',
-    type: 'raster',
-    url: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+    tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
     attribution:
         '&copy; <a href="http://www.esri.com/" target="_blank">Esri</a>' +
         ' i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
     maxZoom: 18,
 }
-const tfTransport: RasterStyle = {
+const tfTransport: RasterStyleEntry = {
     name: 'TF Transport',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://b.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://c.tile.thunderforest.com/transport/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
@@ -84,10 +89,9 @@ const tfTransport: RasterStyle = {
         osmAttribution +
         ', <a href="https://www.thunderforest.com/maps/transport/" target="_blank">Thunderforest Transport</a>',
 }
-const tfCycle: RasterStyle = {
+const tfCycle: RasterStyleEntry = {
     name: 'TF Cycle',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://b.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://c.tile.thunderforest.com/cycle/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
@@ -96,10 +100,9 @@ const tfCycle: RasterStyle = {
         osmAttribution +
         ', <a href="https://www.thunderforest.com/maps/opencyclemap/" target="_blank">Thunderforest Cycle</a>',
 }
-const tfOutdoors: RasterStyle = {
+const tfOutdoors: RasterStyleEntry = {
     name: 'TF Outdoors',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://b.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://c.tile.thunderforest.com/outdoors/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
@@ -108,10 +111,9 @@ const tfOutdoors: RasterStyle = {
         osmAttribution +
         ', <a href="https://www.thunderforest.com/maps/outdoors/" target="_blank">Thunderforest Outdoors</a>',
 }
-const tfAtlas: RasterStyle = {
+const tfAtlas: RasterStyleEntry = {
     name: 'TF Atlas',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://a.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://b.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
         'https://c.tile.thunderforest.com/atlas/{z}/{x}/{y}@2x.png?apikey=' + thunderforestApiKey,
@@ -119,10 +121,9 @@ const tfAtlas: RasterStyle = {
     attribution:
         osmAttribution + ', <a href="https://thunderforest.com/maps/atlas/" target="_blank">Thunderforest Atlas</a>',
 }
-const kurviger: RasterStyle = {
+const kurviger: RasterStyleEntry = {
     name: 'Kurviger Liberty',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://a-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
         'https://b-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
         'https://c-tiles.mapilion.com/raster/styles/kurviger-liberty/{z}/{x}/{y}@2x.png?key=' + kurvigerApiKey,
@@ -133,34 +134,30 @@ const kurviger: RasterStyle = {
         osmAttribution +
         ',&copy; <a href="https://kurviger.de/" target="_blank">Kurviger</a> &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',
 }
-const mapillion: VectorStyle = {
+const mapillion: VectorStyleEntry = {
     name: 'Mapilion',
-    type: 'vector',
-    url: 'https://tiles.mapilion.com/assets/osm-bright/style.json?key=' + kurvigerApiKey,
+    styleUrl: 'https://tiles.mapilion.com/assets/osm-bright/style.json?key=' + kurvigerApiKey,
     attribution:
         osmAttribution +
         ', &copy; <a href="https://mapilion.com/attribution" target="_blank">Mapilion</a> <a href="http://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a>',
 }
-const osmDe: RasterStyle = {
+const osmDe: RasterStyleEntry = {
     name: 'OpenStreetmap.de',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://a.tile.openstreetmap.de/{z}/{x}/{y}.png',
         'https://b.tile.openstreetmap.de/{z}/{x}/{y}.png',
         'https://c.tile.openstreetmap.de/{z}/{x}/{y}.png',
     ],
     attribution: osmAttribution,
 }
-const lyrk: RasterStyle = {
+const lyrk: RasterStyleEntry = {
     name: 'Lyrk',
-    type: 'raster',
-    url: ['https://tiles.lyrk.org/lr/{z}/{x}/{y}?apikey=6e8cfef737a140e2a58c8122aaa26077'],
+    tiles: ['https://tiles.lyrk.org/lr/{z}/{x}/{y}?apikey=6e8cfef737a140e2a58c8122aaa26077'],
     attribution: osmAttribution + ', <a href="https://geodienste.lyrk.de/">Lyrk</a>',
 }
-const wanderreitkarte: RasterStyle = {
+const wanderreitkarte: RasterStyleEntry = {
     name: 'WanderReitKarte',
-    type: 'raster',
-    url: [
+    tiles: [
         'https://topo.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
         'https://topo2.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
         'https://topo3.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
@@ -168,16 +165,13 @@ const wanderreitkarte: RasterStyle = {
     ],
     attribution: osmAttribution + ', <a href="https://wanderreitkarte.de" target="_blank">WanderReitKarte</a>',
 }
-const sorbian: RasterStyle = {
+const sorbian: RasterStyleEntry = {
     name: 'Sorbian Language',
-    type: 'raster',
-    url: ['https://a.tile.openstreetmap.de/tilesbw/osmhrb/{z}/{x}/{y}.png'],
+    tiles: ['https://a.tile.openstreetmap.de/tilesbw/osmhrb/{z}/{x}/{y}.png'],
     attribution: osmAttribution + ', <a href="https://www.alberding.eu/">&copy; Alberding GmbH, CC-BY-SA</a>',
 }
 
-const styleOptions: StyleOption[] = [
-    mapTiler,
-    mapTilerSatellite,
+const mapBoxRasterStyles: MapboxStyle[] = [
     osmOrg,
     omniscale,
     esriSatellite,
@@ -186,34 +180,90 @@ const styleOptions: StyleOption[] = [
     tfOutdoors,
     tfAtlas,
     kurviger,
-    mapillion,
     osmDe,
     // The original client has these but those options yield cors errors with mapbox yields a cors error
     // lyrk,
     // wanderreitkarte,
     // This works but is extremely slow with mapbox
     // sorbian
-]
+].map(entry => {
+    return {
+        name: entry.name,
+        style: {
+            version: 8,
+            sources: {
+                'raster-source': {
+                    type: 'raster',
+                    tiles: entry.tiles,
+                    attribution: entry.attribution,
+                    tileSize: 256,
+                    maxzoom: entry.maxZoom ? entry.maxZoom : 22,
+                },
+            },
+            layers: [
+                {
+                    id: 'raster-layer',
+                    type: 'raster',
+                    source: 'raster-source',
+                },
+            ],
+        },
+    }
+})
 
 export default class MapOptionsStore extends Store<MapOptionsStoreState> {
+    loadStyles() {
+        const entries = [mapTiler, mapTilerSatellite, mapillion]
+        Promise.all(
+            entries.map(entry => {
+                return fetch(entry.styleUrl)
+                    .then(res => res.json())
+                    .then(style => {
+                        return { name: entry.name, style: style }
+                    })
+                    .catch(_ => console.warn(`Could not load map style: ${entry.name}`))
+            })
+        )
+            .then(vectorStyles => {
+                // ignore vector styles that could not be loaded and add raster styles
+                const mapStyles = vectorStyles.filter(style => !!style).concat(mapBoxRasterStyles) as MapboxStyle[]
+                Dispatcher.dispatch(new MapStylesReceived(mapStyles))
+            })
+            .catch(e => Dispatcher.dispatch(new ErrorAction(e.message)))
+    }
+
     protected getInitialState(): MapOptionsStoreState {
-        const selectedStyle = styleOptions.find(s => s.name === config.defaultTiles)
-        if (!selectedStyle)
-            console.warn(
-                `Could not find tile layer specified in config: '${config.defaultTiles}', using default instead`
-            )
         return {
-            selectedStyle: selectedStyle ? selectedStyle : mapTiler,
-            styleOptions,
+            mapStyles: [],
+            selectedMapStyle: {
+                name: '',
+                style: {
+                    version: 8,
+                    sources: {},
+                    layers: [],
+                },
+            },
             isMapLoaded: false,
         }
     }
 
     reduce(state: MapOptionsStoreState, action: Action): MapOptionsStoreState {
-        if (action instanceof SelectMapStyle) {
+        if (action instanceof MapStylesReceived) {
+            const mapStyles = action.mapStyles
+            const selectedMapStyle = mapStyles.find(s => s.name === config.defaultTiles)
+            if (!selectedMapStyle)
+                console.warn(
+                    `Could not find tile layer specified in config: '${config.defaultTiles}', using default instead`
+                )
             return {
                 ...state,
-                selectedStyle: action.styleOption,
+                mapStyles: mapStyles,
+                selectedMapStyle: selectedMapStyle ? selectedMapStyle : mapStyles[0],
+            }
+        } else if (action instanceof SelectMapStyle) {
+            return {
+                ...state,
+                selectedMapStyle: action.mapStyle,
             }
         } else if (action instanceof MapIsLoaded) {
             return {

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -251,16 +251,18 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
     reduce(state: MapOptionsStoreState, action: Action): MapOptionsStoreState {
         if (action instanceof MapStylesReceived) {
             const mapStyles = action.mapStyles
-            const selectedMapStyle = mapStyles.find(s => s.name === config.defaultTiles)
-            if (!selectedMapStyle)
+            let selectedMapStyle = mapStyles.find(s => s.name === config.defaultTiles)
+            if (!selectedMapStyle) {
                 console.warn(
                     `Could not find tile layer specified in config: '${config.defaultTiles}', using default instead`
                 )
+                selectedMapStyle = mapStyles[0]
+            }
             return {
                 ...state,
                 mapStyles: mapStyles,
-                selectedMapStyle: selectedMapStyle ? selectedMapStyle : mapStyles[0],
-                firstSymbolLayerId: selectedMapStyle ? getFirstSymbolLayer(selectedMapStyle) : undefined,
+                selectedMapStyle: selectedMapStyle,
+                firstSymbolLayerId: getFirstSymbolLayer(selectedMapStyle),
             }
         } else if (action instanceof SelectMapStyle) {
             return {


### PR DESCRIPTION
See #109

The Mapbox style consists of many layers with different types. Layers with type 'symbol' should be shown on top of all other layers including our route path layer. Otherwise street labels etc. will be hidden or hard to read. Mapbox offers a 'beforeId' option that allows specifying the position of custom map layers. So basically all we need to do is setting `beforeId` to the first symbol layer of the currently used map style. The main issue with this is that so far we only pass the url of the map style file to Mapbox which is then loaded by Mapbox internally. Therefore we cannot easily figure out which one is the first symbol layer.

In this PR I therefore:

* load all (three to be exact) Mapbox styles when the app starts and keep them in `MapOptionsStore`
* extract the first symbol layer from the loaded style
* use the id of this layer as `beforeId` when creating the paths layer

I think keeping the Mapbox style in `MapOptionsStore` is fine (I actually think it is better) rather than trying to 'hide' Mapbox related stuff from our state store. Just the fact alone that we are dealing with urls pointing to *Mapbox* styles is Mapbox specific anyway. This way we also get rid of the workaround introduced for #122 and there is no need to deal with things like `url: string | string[]` where `url` could be pointing to a mapbox style or might be a list of tile urls.

Loading the style files eagerly when the app starts is just one way this can be done. We could also do this lazily or every time the map style changes (like we currently do), but it is quite fast anyway, and pretty much negligible compared to the loading times for the different tiles:

![image](https://user-images.githubusercontent.com/17603532/126401011-c49c0586-20dd-4dab-a17e-9b3213f08c3f.png)

todo: 

* [ ] currently there are some ugly errors in the console like this: (I don't really understand why)
```
// `water_name_line` is the first symbol layer
mapbox.js:30 Error: Layer with id "water_name_line" does not exist on this map.
```
   ~~Probably related to this: The labels are hidden until we change the map layer for the first time~~ (fixed)
* [ ] Are there any downsides? Does it make sense to fetch the mapbox style manually? Or should we even include it in the bundle?
* [ ] Reducing the opacity of the path layer might still be necessary:
![image](https://user-images.githubusercontent.com/17603532/126402107-e5c09967-298b-4e8d-803a-434ece7013cb.png)
