### PR TITLE
accept coordinates as input

### DIFF
--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -50,13 +50,17 @@ export function coordinateToText(coord: Coordinate): string {
     return Math.round(coord.lat * 1e6) / 1e6 + ',' + Math.round(coord.lng * 1e6) / 1e6
 }
 
-export function textToCoordinate(text: string): Coordinate {
-    const split = text.split(/[,|;| |-|\/]/)
+export function textToCoordinate(text: string): Coordinate | null {
+    // this splits the string at ',' or ' '. The filter filters out empty results
+    // in case something like 1.0, 2.0 was supplied.
+    const split = text.split(/[,| s]/).filter(s => s)
 
-    if (split.length !== 2) throw Error('must be two elements')
+    if (split.length !== 2) return null
 
-    return {
+    const result = {
         lat: Number.parseFloat(split[0]),
         lng: Number.parseFloat(split[1]),
     }
+
+    return isNaN(result.lng) || isNaN(result.lat) ? null : result
 }

--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -71,22 +71,16 @@ export default function AddressInput(props: AddressInputProps) {
                     break
                 case 'Enter':
                 case 'Tab':
-                    if (autocompleteItems.length === 0) {
-                        try {
-                            const coord = textToCoordinate(text)
-                            props.onAddressSelected(text, coord)
-                            break
-                        } catch (e) {
-                            // nothing
-                        }
+                    // try to parse input as coordinate. Otherwise use autocomplete results
+                    const coordinate = textToCoordinate(text)
+                    if (coordinate) {
+                        props.onAddressSelected(text, coordinate)
+                    } else if (autocompleteItems.length !== 0) {
+                        // by default use the first result, otherwise the highlighted one
+                        const index = highlightedResult >= 0 ? highlightedResult : 0
+                        onAutocompleteSelected(autocompleteItems[index], props.onAddressSelected)
                     }
-                    // by default use the first result, otherwise the highlighted one
-                    const index = highlightedResult >= 0 ? highlightedResult : 0
-
-                    // it seems like the order of the blur and onAddressSelected statement is important...
                     searchInput.current!.blur()
-                    onAutocompleteSelected(autocompleteItems[index], props.onAddressSelected)
-
                     break
             }
         },
@@ -107,7 +101,8 @@ export default function AddressInput(props: AddressInputProps) {
                     ref={searchInput}
                     onChange={e => {
                         setText(e.target.value)
-                        geocoder.request(e.target.value)
+                        const coordinate = textToCoordinate(e.target.value)
+                        if (!coordinate) geocoder.request(e.target.value)
                         props.onChange(e.target.value)
                     }}
                     onKeyDown={onKeypress}
@@ -137,7 +132,6 @@ export default function AddressInput(props: AddressInputProps) {
                         items={autocompleteItems}
                         highlightedItem={autocompleteItems[highlightedResult]}
                         onSelect={item => {
-                            // it seems like the order of the blur and onAddressSelected statement is important...
                             searchInput.current!.blur()
                             onAutocompleteSelected(item, props.onAddressSelected)
                         }}

--- a/test/Converters.test.ts
+++ b/test/Converters.test.ts
@@ -1,0 +1,19 @@
+import { textToCoordinate } from '@/Converters'
+
+describe('Converters', function () {
+    describe('textToCoordinate', function () {
+        it('should convert 2 digits separated by ","', function () {
+            expect(textToCoordinate('1.2345, 2.6534')).toEqual({ lat: 1.2345, lng: 2.6534 })
+        })
+        it('should convert 2 digits separated by " "', function () {
+            expect(textToCoordinate('1.2345   2.6534')).toEqual({ lat: 1.2345, lng: 2.6534 })
+        })
+        it('should return null if not 2 elements are found', function () {
+            expect(textToCoordinate('first second third')).toBeNull()
+            expect(textToCoordinate('1.2345')).toBeNull()
+        })
+        it('should return null if any of the elements is NaN', function () {
+            expect(textToCoordinate('2.6534 second')).toBeNull()
+        })
+    })
+})


### PR DESCRIPTION
fixes #114 

So, it is possible to enter lat lng coordinates now. They are only accepted when there is no auto suggestion present. It is kind of hard though to find coordinates which don't have any geocoding results. 

What should be the behavior here @karussell? Maybe check whether a value can be parsed as coordinate and only fetch geocoding results if not? Or fetch geocoding results in any case but only select the first item of the list if the entered text can't be parsed as a coordinate?