### PR TITLE
disable user selection on ios

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -8,6 +8,7 @@
     grid-template-rows: 100%;
     justify-content: space-between;
     overflow: auto;
+    -webkit-user-select: none;
 }
 
 .map {
@@ -39,7 +40,6 @@
 
 .routingResult {
     overflow: auto;
-    min-height: 5rem;
 }
 
 .mapOptions {


### PR DESCRIPTION
fixes #93 

The only way I was able to disable the user selection on iOS when the map has a long press to bring up the context menu was to set ```-webkit-user-select: none``` on the app-wrapper level. I tried to enable selection for the routing results and the sidebar, but somehow performing a long press on the map always selects things in the search box. 

I would assume that copying text from this application on a phone is less important than random selects of elements in the UI. 