### PR TITLE
Insert via points at closest road segment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ function LargeScreenLayout({ query, route, viewport, mapLayers, error, mapOption
                         viewport={viewport}
                         styleOption={mapOptions.selectedStyle}
                         queryPoints={query.queryPoints}
+                        route={route}
                         mapLayers={mapLayers}
                     />
                 }
@@ -163,6 +164,7 @@ function SmallScreenLayout({ query, route, viewport, mapLayers, error, mapOption
                     viewport={viewport}
                     queryPoints={query.queryPoints}
                     styleOption={mapOptions.selectedStyle}
+                    route={route}
                     mapLayers={mapLayers}
                 />
             </div>

--- a/src/distUtils.ts
+++ b/src/distUtils.ts
@@ -1,0 +1,27 @@
+import { Coordinate } from '@/stores/QueryStore'
+
+/**
+ * Calculates the great-circle distance between two points on Earth given the latitudes and longitudes
+ * assuming that Earth is a sphere with radius 6371km. The result is returned in meters.
+ */
+export function calcDist(point1: Coordinate, point2: Coordinate): number {
+    const lat1 = point1.lat
+    const lat2 = point2.lat
+    const lon1 = point1.lng
+    const lon2 = point2.lng
+    const sinDeltaLat = Math.sin(toRad(lat2 - lat1) / 2)
+    const sinDeltaLon = Math.sin(toRad(lon2 - lon1) / 2)
+    return (
+        6371000 *
+        2 *
+        Math.asin(
+            Math.sqrt(
+                sinDeltaLat * sinDeltaLat + sinDeltaLon * sinDeltaLon * Math.cos(toRad(lat1)) * Math.cos(toRad(lat2))
+            )
+        )
+    )
+}
+
+export function toRad(deg: number): number {
+    return deg * 0.017453292519943295
+}

--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -9,15 +9,17 @@ import { ViewportStoreState } from '@/stores/ViewportStore'
 import { PopupComponent } from '@/map/Popup'
 import { MapLayer } from '@/layers/MapLayer'
 import styles from './Map.module.css'
+import { RouteStoreState } from '@/stores/RouteStore'
 
 type MapProps = {
     viewport: ViewportStoreState
     queryPoints: QueryPoint[]
     styleOption: StyleOption
+    route: RouteStoreState
     mapLayers: MapLayer[]
 }
 
-export default function ({ viewport, styleOption, queryPoints, mapLayers }: MapProps) {
+export default function ({ viewport, styleOption, queryPoints, route, mapLayers }: MapProps) {
     const [popupCoordinate, setPopupCoordinate] = useState<Coordinate | null>(null)
     const longTouchHandler = new LongTouchHandler(e => setPopupCoordinate({ lng: e.lngLat[0], lat: e.lngLat[1] }))
 
@@ -72,6 +74,7 @@ export default function ({ viewport, styleOption, queryPoints, mapLayers }: MapP
                     <PopupComponent
                         coordinate={popupCoordinate}
                         queryPoints={queryPoints}
+                        route={route}
                         onSelect={() => setPopupCoordinate(null)}
                     />
                 </Popup>

--- a/src/map/Popup.tsx
+++ b/src/map/Popup.tsx
@@ -48,7 +48,9 @@ export function PopupComponent({
                     }),
                 }
             })
-            // we silently assume the way points are the same for all routes (and they are)
+            // note that we can use the index returned by findNextWayPoint no matter which route alternative was found
+            // to be closest to the clicked location, because for every route the n-th snapped_waypoint corresponds to
+            // the n-th query point
             const index = findNextWayPoint(routes, coordinate).nextWayPoint
             Dispatcher.dispatch(new AddPoint(index, coordinate, true))
         }

--- a/src/map/Popup.tsx
+++ b/src/map/Popup.tsx
@@ -4,14 +4,18 @@ import styles from './Popup.module.css'
 import { Coordinate, QueryPoint, QueryPointType } from '@/stores/QueryStore'
 import Dispatcher from '@/stores/Dispatcher'
 import { AddPoint, SetPoint, SetViewportToPoint } from '@/actions/Actions'
+import { RouteStoreState } from '@/stores/RouteStore'
+import { findNextWayPoint } from '@/map/findNextWayPoint'
 
 export function PopupComponent({
     coordinate,
     queryPoints,
+    route,
     onSelect,
 }: {
     coordinate: Coordinate
     queryPoints: QueryPoint[]
+    route: RouteStoreState
     onSelect: () => void
 }) {
     const dispatchSetPoint = function (point: QueryPoint, coordinate: Coordinate) {
@@ -26,7 +30,7 @@ export function PopupComponent({
         )
     }
 
-    const setViaPoint = function (points: QueryPoint[]) {
+    const setViaPoint = function (points: QueryPoint[], route: RouteStoreState) {
         const viaPoints = points.filter(point => point.type === QueryPointType.Via)
         const point = viaPoints.find(point => !point.isInitialized)
         onSelect()
@@ -34,7 +38,19 @@ export function PopupComponent({
         if (point) {
             dispatchSetPoint(point, coordinate)
         } else {
-            Dispatcher.dispatch(new AddPoint(viaPoints.length + 1, coordinate, true))
+            const routes = route.routingResult.paths.map(p => {
+                return {
+                    coordinates: p.points.coordinates.map(pos => {
+                        return { lat: pos[1], lng: pos[0] }
+                    }),
+                    wayPoints: p.snapped_waypoints.coordinates.map(pos => {
+                        return { lat: pos[1], lng: pos[0] }
+                    }),
+                }
+            })
+            // we silently assume the way points are the same for all routes (and they are)
+            const index = findNextWayPoint(routes, coordinate).nextWayPoint
+            Dispatcher.dispatch(new AddPoint(index, coordinate, true))
         }
     }
 
@@ -55,7 +71,7 @@ export function PopupComponent({
             <button
                 className={styles.entry}
                 disabled={disableViaPoint(queryPoints)}
-                onClick={() => setViaPoint(queryPoints)}
+                onClick={() => setViaPoint(queryPoints, route)}
             >
                 Via here
             </button>

--- a/src/map/findNextWayPoint.ts
+++ b/src/map/findNextWayPoint.ts
@@ -1,4 +1,5 @@
 import { Coordinate } from '@/stores/QueryStore'
+import { calcDist } from '@/distUtils'
 
 /**
  * Finds the way-point that follows the part of a route that is closest to a given location
@@ -40,28 +41,3 @@ export function findNextWayPoint(
     }
 }
 
-/**
- * Calculates the great-circle distance between two points on Earth given the latitudes and longitudes
- * assuming that Earth is a sphere with radius 6371km. The result is returned in meters.
- */
-function calcDist(point1: Coordinate, point2: Coordinate): number {
-    const lat1 = point1.lat
-    const lat2 = point2.lat
-    const lon1 = point1.lng
-    const lon2 = point2.lng
-    const sinDeltaLat = Math.sin(toRad(lat2 - lat1) / 2)
-    const sinDeltaLon = Math.sin(toRad(lon2 - lon1) / 2)
-    return (
-        6371000 *
-        2 *
-        Math.asin(
-            Math.sqrt(
-                sinDeltaLat * sinDeltaLat + sinDeltaLon * sinDeltaLon * Math.cos(toRad(lat1)) * Math.cos(toRad(lat2))
-            )
-        )
-    )
-}
-
-function toRad(deg: number): number {
-    return deg * 0.017453292519943295
-}

--- a/src/map/findNextWayPoint.ts
+++ b/src/map/findNextWayPoint.ts
@@ -1,0 +1,67 @@
+import { Coordinate } from '@/stores/QueryStore'
+
+/**
+ * Finds the way-point that follows the part of a route that is closest to a given location
+ *
+ * @param routes one or more routes to be considered
+ * @param location the location for which the closest route should be found
+ */
+export function findNextWayPoint(
+    routes: { coordinates: Coordinate[]; wayPoints: Coordinate[] }[],
+    location: Coordinate
+): { closestRoute: number; nextWayPoint: number; distance: number } {
+    if (
+        routes.length < 1 ||
+        routes.some(
+            r => r.coordinates.length < 2 || r.wayPoints.length < 2 || r.wayPoints.length > r.coordinates.length
+        )
+    )
+        throw new Error('Invalid input when trying to find the next way point')
+    let minDistance = Number.MAX_VALUE
+    let closestRoute = 0
+    let nextWayPoint = 0
+    routes.forEach((route, routeIndex) => {
+        let wayPoint = 0
+        route.coordinates.forEach(point => {
+            if (calcDist(point, route.wayPoints[wayPoint]) < 1)
+                wayPoint = Math.min(route.wayPoints.length - 1, wayPoint + 1)
+            const distance = calcDist(point, location)
+            if (distance < minDistance) {
+                minDistance = distance
+                closestRoute = routeIndex
+                nextWayPoint = wayPoint == route.wayPoints.length ? wayPoint - 1 : wayPoint
+            }
+        })
+    })
+    return {
+        closestRoute: closestRoute,
+        nextWayPoint: nextWayPoint,
+        distance: minDistance,
+    }
+}
+
+/**
+ * Calculates the great-circle distance between two points on Earth given the latitudes and longitudes
+ * assuming that Earth is a sphere with radius 6371km. The result is returned in meters.
+ */
+function calcDist(point1: Coordinate, point2: Coordinate): number {
+    const lat1 = point1.lat
+    const lat2 = point2.lat
+    const lon1 = point1.lng
+    const lon2 = point2.lng
+    const sinDeltaLat = Math.sin(toRad(lat2 - lat1) / 2)
+    const sinDeltaLon = Math.sin(toRad(lon2 - lon1) / 2)
+    return (
+        6371000 *
+        2 *
+        Math.asin(
+            Math.sqrt(
+                sinDeltaLat * sinDeltaLat + sinDeltaLon * sinDeltaLon * Math.cos(toRad(lat1)) * Math.cos(toRad(lat2))
+            )
+        )
+    )
+}
+
+function toRad(deg: number): number {
+    return deg * 0.017453292519943295
+}

--- a/test/findNextWayPoint.test.ts
+++ b/test/findNextWayPoint.test.ts
@@ -1,0 +1,84 @@
+import { Coordinate } from '@/stores/QueryStore'
+import { findNextWayPoint } from '@/map/findNextWayPoint'
+
+// test data, can be shown using these url parameters:
+// ?point=52.550,13.352&point=52.547,13.358&point=52.541,13.368&point=52.542,13.376&point=52.542,13.383
+// &point=52.545,13.391&point=52.542,13.408&point=52.539,13.424&point=52.533,13.441&point=52.527,13.447
+// &point=52.533,13.476&point=52.561,13.457&point=52.581,13.397
+const a = point(52.55, 13.352)
+const x1 = point(52.547, 13.358)
+const x2 = point(52.541, 13.368)
+const x3 = point(52.542, 13.376)
+const b = point(52.542, 13.383)
+const x4 = point(52.545, 13.391)
+const x5 = point(52.542, 13.408)
+const c = point(52.539, 13.424)
+const x6 = point(52.533, 13.441)
+const x7 = point(52.527, 13.447)
+const d = point(52.533, 13.476)
+const x8 = point(52.561, 13.457)
+const x9 = point(52.581, 13.397)
+
+describe('findNextWayPoint', function () {
+    it('should work', function () {
+        const routes = [
+            {
+                coordinates: [a, x1, x2, x3, b, x4, x5, c, x6, x7, d],
+                wayPoints: [a, b, c, d],
+            },
+        ]
+
+        const clickLocations = [
+            { point: point(52.567, 13.342), expectedIndex: 1 },
+            { point: point(52.54, 13.378), expectedIndex: 1 },
+            { point: point(52.542, 13.396), expectedIndex: 2 },
+            { point: point(52.526, 13.463), expectedIndex: 3 },
+            { point: point(52.526, 13.519), expectedIndex: 3 },
+        ]
+
+        for (let i = 0; i < clickLocations.length; ++i) {
+            const result = findNextWayPoint(routes, clickLocations[i].point)
+            expect(result.closestRoute).toEqual(0)
+            expect(result.nextWayPoint).toEqual(clickLocations[i].expectedIndex)
+        }
+    })
+
+    it('should work for multiple routes', function () {
+        const routes = [
+            {
+                coordinates: [a, x9, d],
+                wayPoints: [a, d],
+            },
+            {
+                coordinates: [a, x3, d],
+                wayPoints: [a, d],
+            },
+        ]
+        {
+            const result = findNextWayPoint(routes, point(52.53, 13.379))
+            expect(result.closestRoute).toEqual(1)
+            expect(result.nextWayPoint).toEqual(1)
+        }
+        {
+            const result = findNextWayPoint(routes, point(52.577, 13.446))
+            expect(result.closestRoute).toEqual(0)
+            expect(result.nextWayPoint).toEqual(1)
+        }
+    })
+
+    it('should work for round trips', function () {
+        const routes = [
+            {
+                coordinates: [a, x1, x2, x3, b, x4, x5, c, x6, x7, d, x8, x9, a],
+                wayPoints: [a, b, c, d, a],
+            },
+        ]
+
+        const clickLocation = point(52.568, 13.389)
+        expect(findNextWayPoint(routes, clickLocation).nextWayPoint).toEqual(4)
+    })
+})
+
+function point(lat: number, lng: number): Coordinate {
+    return { lat: lat, lng: lng }
+}


### PR DESCRIPTION
Currently new via points that are added using the context menu are added as last (just before the destination), no matter where we click. This PR inserts new via points based on the click location. More precisely, we insert via points between the two way points that are connected by the road segment that comes closest to the click location.

I ported this functionality form GH maps 1 (see https://github.com/graphhopper/graphhopper/pull/791, https://github.com/graphhopper/graphhopper/pull/795, [code](https://github.com/graphhopper/graphhopper/blob/master/web-bundle/src/main/resources/com/graphhopper/maps/js/routeManipulation.js)).

This is part of #37 