### PR TITLE
No more flickering when hovering the path details diagram

### DIFF
--- a/src/pathDetails/PathDetails.module.css
+++ b/src/pathDetails/PathDetails.module.css
@@ -7,7 +7,7 @@
 
 .innerDiv {
     position: relative;
-    pointer-events: all;
+    pointer-events: auto;
     background-color: white;
     border-radius: 0.3rem;
 }


### PR DESCRIPTION
This fixes the flickering of the path detail window described in #134. 
We set `pointer-events: all` in this commit: https://github.com/graphhopper/graphhopper-maps/pull/75/commits/924ee0574d97e82aa4b8d56afe8688e65564c1c0 of this PR: https://github.com/graphhopper/graphhopper-maps/pull/75. Not sure if there is a particular reason we used `all` so far, but using `auto` fixes the issue for me.