### PR TITLE
Deploy: allow manual trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:
 jobs:
   deploy_maps:
     name: Deploy


### PR DESCRIPTION
This will allow us to deploy the latest version manually, even if there was no merge to master.

This will help us debug deployment problems like we have now.