### PR TITLE
Add test for map action receiver (replaces old viewport store test)

### DIFF
--- a/test/stores/MapActionReceiver.test.ts
+++ b/test/stores/MapActionReceiver.test.ts
@@ -1,0 +1,44 @@
+import MapActionReceiver from '@/stores/MapActionReceiver'
+import { PathDetailsRangeSelected, RouteRequestSuccess, ZoomMapToPoint } from '@/actions/Actions'
+import { createMap, getMap } from '@/map/map'
+
+describe('MapActionReceiver', () => {
+    it('should update camera position correctly', () => {
+        const routeStore = {} as any
+        createMap()
+        const receiver = new MapActionReceiver(getMap(), routeStore, () => false)
+        {
+            // simply set to point
+            receiver.receive(new ZoomMapToPoint({ lng: 13, lat: 48 }, 11))
+            expect(getMap().getView().getCenter()![0]).toEqual(13)
+            expect(getMap().getView().getCenter()![1]).toEqual(13)
+            expect(getMap().getView().getZoom()).toEqual(13)
+        }
+        {
+            // set to route ...
+            const selectedPath = { bbox: [10.31, 50.73, 11.19, 51.31] }
+            routeStore.state = { selectedPath }
+            receiver.receive(
+                new RouteRequestSuccess(
+                    null as any,
+                    {
+                        paths: [selectedPath],
+                    } as any
+                )
+            )
+            expect(getMap().getView().getCenter()![0]).toBeCloseTo(10.5, 1)
+            expect(getMap().getView().getCenter()![1]).toBeCloseTo(50.9, 1)
+            expect(getMap().getView().getZoom()).toBeCloseTo(8.8, 1)
+            // ... select path details
+            receiver.receive(new PathDetailsRangeSelected([10.46, 50.88, 10.47, 50.9]))
+            expect(getMap().getView().getCenter()![0]).toBeCloseTo(10.46, 2)
+            expect(getMap().getView().getCenter()![1]).toBeCloseTo(50.89, 2)
+            expect(getMap().getView().getZoom()).toBeCloseTo(13.7, 1)
+            // ... deselect path details again -> we are back to the route bbox
+            receiver.receive(new PathDetailsRangeSelected(null))
+            expect(getMap().getView().getCenter()![0]).toBeCloseTo(10.5, 1)
+            expect(getMap().getView().getCenter()![1]).toBeCloseTo(50.9, 1)
+            expect(getMap().getView().getZoom()).toBeCloseTo(8.8, 1)
+        }
+    })
+})


### PR DESCRIPTION
Here I tried adding a new test to replace `ViewportStore.test.ts` after #159.
Unfortunately I get the following error:

```
    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/en/ecmascript-modules for how to enable it.
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /home/me/code/routing/graphhopper/gh-maps-react/node_modules/ol/proj.js:55
    import Projection from './proj/Projection.js';
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module

      1 | import { Action, ActionReceiver } from '@/stores/Dispatcher'
      2 | import { Map } from 'ol'
    > 3 | import { fromLonLat } from 'ol/proj'
        | ^
      4 | import {
      5 |     PathDetailsRangeSelected,
      6 |     RouteRequestSuccess,

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1350:14)
      at Object.<anonymous> (src/stores/MapActionReceiver.ts:3:1)
```

@Janekdererste any idea how to fix this? This test might not be crazy important but it might happen we see the same problem in another place later on.