### PR TITLE
154 parse vehicle profile

### DIFF
--- a/src/NavBar.ts
+++ b/src/NavBar.ts
@@ -68,9 +68,12 @@ export default class NavBar {
             })
     }
 
-    private static parseProfile(url: URL) {
-        let profileKey = url.searchParams.get('profile')
-        return profileKey ? profileKey : ''
+    private static parseProfile(url: URL): string {
+        // we can cast to string since we test for presence before
+        if (url.searchParams.has('profile')) return url.searchParams.get('profile') as string
+        if (url.searchParams.has('vehicle')) return url.searchParams.get('vehicle') as string
+
+        return ''
     }
 
     private parseLayer(url: URL) {

--- a/src/NavBar.ts
+++ b/src/NavBar.ts
@@ -1,7 +1,7 @@
 import { coordinateToText } from '@/Converters'
 import { Bbox, RoutingProfile } from '@/api/graphhopper'
 import Dispatcher from '@/stores/Dispatcher'
-import { SelectMapStyle, SetInitialBBox, SetRoutingParametersAtOnce } from '@/actions/Actions'
+import { ClearPoints, SelectMapStyle, SetInitialBBox, SetRoutingParametersAtOnce } from '@/actions/Actions'
 // import the window like this so that it can be mocked during testing
 import { window } from '@/Window'
 import QueryStore, { Coordinate, QueryPoint, QueryPointType, QueryStoreState } from '@/stores/QueryStore'
@@ -87,7 +87,7 @@ export default class NavBar {
     parseUrlAndReplaceQuery() {
         this.isIgnoreQueryStoreUpdates = true
 
-        //const parseResult = NavBar.parseUrl(this.appContext.location.href)
+        Dispatcher.dispatch(new ClearPoints())
         const parseResult = this.parseUrl(window.location.href)
 
         // estimate map bounds from url points if there are any. this way we prevent loading tiles for the world view
@@ -98,7 +98,8 @@ export default class NavBar {
         // we want either all the points replaced from the url or we just have one and we want to replace the one default
         // one
         const points = parseResult.points.length > 2 ? parseResult.points : this.fillPoints(parseResult.points)
-        Dispatcher.dispatch(new SetRoutingParametersAtOnce(points, parseResult.profile))
+        const profile = parseResult.profile.name ? parseResult.profile : this.queryStore.state.routingProfile
+        Dispatcher.dispatch(new SetRoutingParametersAtOnce(points, profile))
 
         // add map style
         Dispatcher.dispatch(new SelectMapStyle(parseResult.styleOption))

--- a/src/sidebar/search/RoutingProfiles.tsx
+++ b/src/sidebar/search/RoutingProfiles.tsx
@@ -13,15 +13,17 @@ export default function ({
     routingProfiles: RoutingProfile[]
     selectedProfile: RoutingProfile
 }) {
-    console.log('selected profile is: ' + selectedProfile.name)
-
+    // this first merges profiles set from config and those received from the backend.
     const extraRoutingProfiles: RoutingProfile[] = config.extraProfiles
         ? Object.keys(config.extraProfiles).map(profile => ({ name: profile }))
         : []
-    const b = routingProfiles.concat(extraRoutingProfiles)
-    const allRoutingProfiles = b.find(profile => profile.name === selectedProfile.name)
-        ? b
-        : b.concat([selectedProfile])
+    const validRoutingProfiles = routingProfiles.concat(extraRoutingProfiles)
+
+    // in case the query store has an invalid profile (which we allow, so that an error message can be shown)
+    // this merges the invalid profile into the list, so it can be shown in the select component.
+    const allRoutingProfiles = validRoutingProfiles.find(profile => profile.name === selectedProfile.name)
+        ? validRoutingProfiles
+        : validRoutingProfiles.concat([selectedProfile])
 
     return (
         <select

--- a/src/sidebar/search/RoutingProfiles.tsx
+++ b/src/sidebar/search/RoutingProfiles.tsx
@@ -13,10 +13,16 @@ export default function ({
     routingProfiles: RoutingProfile[]
     selectedProfile: RoutingProfile
 }) {
+    console.log('selected profile is: ' + selectedProfile.name)
+
     const extraRoutingProfiles: RoutingProfile[] = config.extraProfiles
         ? Object.keys(config.extraProfiles).map(profile => ({ name: profile }))
         : []
-    const allRoutingProfiles = routingProfiles.concat(extraRoutingProfiles)
+    const b = routingProfiles.concat(extraRoutingProfiles)
+    const allRoutingProfiles = b.find(profile => profile.name === selectedProfile.name)
+        ? b
+        : b.concat([selectedProfile])
+
     return (
         <select
             className={styles.profileSelect}
@@ -55,6 +61,6 @@ function getEmoji(profile: RoutingProfile) {
         case 'racingbike':
             return '🚴‍'
         default:
-            return ''
+            return '🚩'
     }
 }

--- a/src/stores/QueryStore.ts
+++ b/src/stores/QueryStore.ts
@@ -178,12 +178,8 @@ export default class QueryStore extends Store<QueryStoreState> {
             }
             return this.routeIfAllPointsSet(newState)
         } else if (action instanceof InfoReceived) {
-            // this is the case if the vehicle was set in the url. Keep it in this case if the backend supports it
-            if (state.routingProfile.name && action.result.profiles.find(p => p.name === state.routingProfile.name))
-                return state
-
-            // if we haven't received anything
-            if (action.result.profiles.length <= 0) return state
+            // if a routing profile was in the url keep it regardless. Also, do nothing if no routing profiles were received
+            if (state.routingProfile.name || action.result.profiles.length <= 0) return state
 
             // otherwise select the first entry as default routing mode
             const profile = action.result.profiles[0]

--- a/src/stores/QueryStore.ts
+++ b/src/stores/QueryStore.ts
@@ -187,10 +187,10 @@ export default class QueryStore extends Store<QueryStoreState> {
 
             // otherwise select the first entry as default routing mode
             const profile = action.result.profiles[0]
-            return {
+            return this.routeIfAllPointsSet({
                 ...state,
                 routingProfile: profile,
-            }
+            })
         } else if (action instanceof SetVehicleProfile) {
             const newState: QueryStoreState = {
                 ...state,

--- a/src/stores/RouteStore.ts
+++ b/src/stores/RouteStore.ts
@@ -1,6 +1,6 @@
 import Store from '@/stores/Store'
 import { Action } from '@/stores/Dispatcher'
-import { ClearRoute, RouteRequestSuccess, SetPoint, SetSelectedPath } from '@/actions/Actions'
+import { ClearPoints, ClearRoute, RemovePoint, RouteRequestSuccess, SetPoint, SetSelectedPath } from '@/actions/Actions'
 import QueryStore, { RequestState } from '@/stores/QueryStore'
 import { Path, RoutingArgs, RoutingResult } from '@/api/graphhopper'
 
@@ -51,7 +51,12 @@ export default class RouteStore extends Store<RouteStoreState> {
                 ...state,
                 selectedPath: action.path,
             }
-        } else if (action instanceof SetPoint || action instanceof ClearRoute) {
+        } else if (
+            action instanceof SetPoint ||
+            action instanceof ClearRoute ||
+            action instanceof ClearPoints ||
+            action instanceof RemovePoint
+        ) {
             return this.getInitialState()
         }
         return state

--- a/test/NavBar.test.ts
+++ b/test/NavBar.test.ts
@@ -23,6 +23,16 @@ jest.mock('@/Window', () => ({
     },
 }))
 
+function setUpFunctionality() {
+    // set up functionality
+    const queryStore = new QueryStore(new DummyApi())
+    const mapStore = new MapOptionsStore()
+    Dispatcher.register(queryStore)
+    Dispatcher.register(mapStore)
+    const navBar = new NavBar(queryStore, mapStore)
+    return { queryStore, mapStore, navBar }
+}
+
 describe('NavBar', function () {
     afterEach(() => {
         jest.resetAllMocks()
@@ -86,12 +96,7 @@ describe('NavBar', function () {
             href: url.toString(),
         }
 
-        // set up functionality
-        const queryStore = new QueryStore(new DummyApi())
-        const mapStore = new MapOptionsStore()
-        Dispatcher.register(queryStore)
-        Dispatcher.register(mapStore)
-        const navBar = new NavBar(queryStore, mapStore)
+        const { queryStore, mapStore, navBar } = setUpFunctionality()
 
         // act
         navBar.parseUrlAndReplaceQuery()
@@ -110,18 +115,57 @@ describe('NavBar', function () {
         expect(url.toString()).toEqual(window.location.href)
     })
 
+    it('should parse the url and set no points when no points are set', () => {
+        window.location = {
+            ...window.location,
+            href: 'https://origin.com',
+        }
+        const { queryStore, navBar } = setUpFunctionality()
+        const point1 = queryStore.state.queryPoints[0]
+        const point2 = queryStore.state.queryPoints[1]
+
+        // act
+        navBar.parseUrlAndReplaceQuery()
+
+        //assert
+        // we still want to have 2 points and they should have the same values as before - the ids are changed though
+        // since the store creates new instances of points regardless what is fed with "setallqyeryparamsatonce"
+        expect(queryStore.state.queryPoints.length).toEqual(2)
+        expect(queryStore.state.queryPoints[0].coordinate).toEqual(point1.coordinate)
+        expect(queryStore.state.queryPoints[1].coordinate).toEqual(point2.coordinate)
+        expect(queryStore.state.queryPoints[0].queryText).toEqual(point1.queryText)
+        expect(queryStore.state.queryPoints[1].queryText).toEqual(point2.queryText)
+    })
+
+    it('should parse the url and invalidate old points', () => {
+        window.location = {
+            ...window.location,
+            href: 'https://origin.com',
+        }
+        const { queryStore, navBar } = setUpFunctionality()
+        Dispatcher.dispatch(
+            new SetPoint({
+                ...queryStore.state.queryPoints[0],
+                isInitialized: true,
+            })
+        )
+
+        //act
+        navBar.parseUrlAndReplaceQuery()
+
+        // assert
+        expect(queryStore.state.queryPoints.length).toEqual(2)
+        expect(queryStore.state.queryPoints[0].isInitialized).toBeFalsy()
+        expect(queryStore.state.queryPoints[1].isInitialized).toBeFalsy()
+    })
+
     it('should parse the url and set defaults for layer if not provided', () => {
         window.location = {
             ...window.location,
             href: 'https://origin.com',
         }
 
-        // set up functionality
-        const queryStore = new QueryStore(new DummyApi())
-        const mapStore = new MapOptionsStore()
-        Dispatcher.register(queryStore)
-        Dispatcher.register(mapStore)
-        const navBar = new NavBar(queryStore, mapStore)
+        const { queryStore, mapStore, navBar } = setUpFunctionality()
 
         // act
         navBar.parseUrlAndReplaceQuery()
@@ -133,6 +177,30 @@ describe('NavBar', function () {
         expect(queryStore.state.routingProfile.name).toEqual('')
 
         expect(mapStore.state.selectedStyle.name).toEqual(config.defaultTiles)
+    })
+
+    it('should parse the url and set defaults for profile if not set', () => {
+        const layername = 'Omniscale'
+        const url = new URL(window.location.origin + window.location.pathname)
+        url.searchParams.append('layer', layername)
+        window.location = {
+            ...window.location,
+            href: url.toString(),
+        }
+
+        const { queryStore, mapStore, navBar } = setUpFunctionality()
+        Dispatcher.dispatch(new SetVehicleProfile({ name: 'some-profile' }))
+        const defaultProfile = queryStore.state.routingProfile
+
+        // act
+        navBar.parseUrlAndReplaceQuery()
+
+        //assert
+        expect(queryStore.state.queryPoints.length).toEqual(2)
+        expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
+        expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
+        expect(queryStore.state.routingProfile.name).toEqual(defaultProfile.name)
+        expect(mapStore.state.selectedStyle.name).toEqual(layername)
     })
 
     it('should update the query store state on popstate (back-pressed)', () => {
@@ -162,12 +230,7 @@ describe('NavBar', function () {
             href: url.toString(),
         }
 
-        // set up functionality
-        const queryStore = new QueryStore(new DummyApi())
-        const mapStore = new MapOptionsStore()
-        Dispatcher.register(queryStore)
-        Dispatcher.register(mapStore)
-        new NavBar(queryStore, mapStore)
+        const { queryStore, mapStore } = setUpFunctionality()
 
         // act
         callbacks.forEach(callback => callback('popstate'))

--- a/test/NavBar.test.ts
+++ b/test/NavBar.test.ts
@@ -203,6 +203,26 @@ describe('NavBar', function () {
         expect(mapStore.state.selectedStyle.name).toEqual(layername)
     })
 
+    it('should parse the url and set routing profile for legacy "vehicle" param', () => {
+        const layername = 'Omniscale'
+        const profileName = 'some-profile-name'
+        const url = new URL(window.location.origin + window.location.pathname)
+        url.searchParams.append('layer', layername)
+        url.searchParams.append('vehicle', profileName)
+        const { queryStore, navBar } = setUpFunctionality()
+
+        window.location = {
+            ...window.location,
+            href: url.toString(),
+        }
+
+        // act
+        navBar.parseUrlAndReplaceQuery()
+
+        // assert
+        expect(queryStore.state.routingProfile.name).toEqual(profileName)
+    })
+
     it('should update the query store state on popstate (back-pressed)', () => {
         const callbacks: { (type: string): void }[] = []
         window.addEventListener = jest.fn((type: any, listener: any) => {

--- a/test/stores/QueryStore.test.ts
+++ b/test/stores/QueryStore.test.ts
@@ -244,7 +244,7 @@ describe('QueryStore', () => {
             const newState = store.reduce(
                 state,
                 new InfoReceived({
-                    profiles: [{ name: 'some-other-profile' }, { name: profile }],
+                    profiles: [{ name: 'some-other-profile' }],
                     elevation: true,
                     version: '',
                     import_date: '',
@@ -253,34 +253,6 @@ describe('QueryStore', () => {
             )
 
             expect(newState).toEqual(state)
-        })
-        it('should use the first profile if profile was already set but not in info action', () => {
-            const store = new QueryStore(
-                new ApiMock(() => {
-                    fail("no routing request should be issued when profile hasn't changed")
-                })
-            )
-
-            const presetProfile = 'some-profile'
-            const firstProfileFromInfo = 'first-from-info'
-            const state: QueryStoreState = {
-                ...store.state,
-                routingProfile: {
-                    name: presetProfile,
-                },
-            }
-            const newState = store.reduce(
-                state,
-                new InfoReceived({
-                    profiles: [{ name: firstProfileFromInfo }, { name: 'other-profile-from-info' }],
-                    elevation: true,
-                    version: '',
-                    import_date: '',
-                    bbox: [0, 0, 0, 0],
-                })
-            )
-
-            expect(newState.routingProfile.name).toEqual(firstProfileFromInfo)
         })
         it('should use the first profile received from info endpoint', () => {
             const expectedProfile = {

--- a/test/stores/RouteStore.test.ts
+++ b/test/stores/RouteStore.test.ts
@@ -1,0 +1,83 @@
+import RouteStore from '@/stores/RouteStore'
+import QueryStore, { QueryPoint, QueryPointType } from '@/stores/QueryStore'
+import Api from '@/api/Api'
+import { ApiInfo, GeocodingResult, Path, RoutingArgs, RoutingResult } from '@/api/graphhopper'
+import Dispatcher, { Action } from '@/stores/Dispatcher'
+import { ClearPoints, ClearRoute, RemovePoint, SetPoint, SetSelectedPath } from '@/actions/Actions'
+
+describe('RouteStore', () => {
+    afterEach(() => {
+        Dispatcher.clear()
+    })
+
+    describe('clear route information', () => {
+        it('should revert to initial state on ClearPoints Action', () => {
+            executeTest(new SetPoint(createEmptyQueryPoint()))
+        })
+        it('should revert to initial state on ClearRoute Action', () => {
+            executeTest(new ClearRoute())
+        })
+        it('should revert to initial state on SetPoint Action', () => {
+            executeTest(new ClearPoints())
+        })
+        it('should revert to initial state on RemovePoint Action', () => {
+            executeTest(new RemovePoint(createEmptyQueryPoint()))
+        })
+
+        function executeTest(action: Action) {
+            const store = createStore()
+            const initialState = store.state
+
+            Dispatcher.dispatch(action)
+
+            expect(store.state).toEqual(initialState)
+        }
+    })
+
+    it('Should set selected path', () => {
+        const store = createStore()
+        const pathToSelect: Path = {
+            ...store.state.selectedPath,
+            distance: 1000,
+        }
+
+        Dispatcher.dispatch(new SetSelectedPath(pathToSelect))
+
+        expect(store.state.selectedPath).toEqual(pathToSelect)
+    })
+})
+
+function createStore() {
+    const store = new RouteStore(new QueryStore(new DummyApi()))
+    Dispatcher.register(store)
+    return store
+}
+
+function createEmptyQueryPoint(): QueryPoint {
+    return {
+        isInitialized: false,
+        queryText: '',
+        coordinate: { lat: 0, lng: 0 },
+        id: 0,
+        color: '',
+        type: QueryPointType.To,
+    }
+}
+
+class DummyApi implements Api {
+    geocode(query: string): Promise<GeocodingResult> {
+        throw Error('not implemented')
+    }
+
+    info(): Promise<ApiInfo> {
+        throw Error('not implemented')
+    }
+
+    infoWithDispatch(): void {}
+
+    route(args: RoutingArgs): Promise<RoutingResult> {
+        throw Error('not implemented')
+    }
+
+    routeWithDispatch(args: RoutingArgs): void {}
+}


### PR DESCRIPTION
fixes #154 . As discussed in the issue. The routing profile is now parsed from the url. This is done in two places. 
1. If the url has no profile property, the currently selected routing profile from the ```QueryStore``` is used
2. Since, on start up, the ```QueryStore``` might not have received a routing profile yet, the query store issues a routing request when it recevies a ```InfoReceived``` action. 

I also made sure stale routes are removed from the ```RouteStore``` when Points are removed. 

Most of the added lines are unit tests