### PR TITLE
Write and parse address in url

### DIFF
--- a/test/NavBar.test.ts
+++ b/test/NavBar.test.ts
@@ -7,8 +7,9 @@ import { coordinateToText } from '@/Converters'
 
 // import the window and mock it with jest
 import { window } from '@/Window'
-import MapOptionsStore from '@/stores/MapOptionsStore'
+import MapOptionsStore, { StyleOption } from '@/stores/MapOptionsStore'
 import * as config from 'config'
+import { RoutingProfile } from '@/api/graphhopper'
 
 jest.mock('@/Window', () => ({
     window: {
@@ -23,212 +24,249 @@ jest.mock('@/Window', () => ({
     },
 }))
 
-function setUpFunctionality() {
-    // set up functionality
-    const queryStore = new QueryStore(new DummyApi())
-    const mapStore = new MapOptionsStore()
-    Dispatcher.register(queryStore)
-    Dispatcher.register(mapStore)
-    const navBar = new NavBar(queryStore, mapStore)
-    return { queryStore, mapStore, navBar }
-}
-
 describe('NavBar', function () {
+    let queryStore: QueryStore
+    let mapStore: MapOptionsStore
+    let navBar: NavBar
+    let callbacks: { (type: string): void }[]
+
+    beforeEach(() => {
+        // because we mock the global 'window' object, we also need to mock event listeners.
+        // this must be done before 'new NavBar' is called below, since this subscribes as event listener
+        callbacks = []
+        window.addEventListener = jest.fn((type: any, listener: any) => {
+            callbacks.push(listener)
+        })
+        queryStore = new QueryStore(new DummyApi())
+        mapStore = new MapOptionsStore()
+        navBar = new NavBar(queryStore, mapStore)
+        Dispatcher.register(queryStore)
+        Dispatcher.register(mapStore)
+    })
+
     afterEach(() => {
         jest.resetAllMocks()
         Dispatcher.clear()
     })
 
-    it('should convert query store state into url params on change', function () {
-        // set up navbar with store dependency
-        const queryStore = new QueryStore(new DummyApi())
-        const mapStore = new MapOptionsStore()
-        new NavBar(queryStore, mapStore)
-
-        // set up the data we want to work with
-        const profile = 'my-profile'
-        const layer = 'Lyrk'
-        const point1: QueryPoint = {
-            ...queryStore.state.queryPoints[0],
-            coordinate: { lat: 1, lng: 2 },
-            isInitialized: true,
-        }
-        const point2 = {
-            ...queryStore.state.queryPoints[1],
-            coordinate: { lat: 10, lng: 10 },
-            isInitialized: true,
-        }
-        const expectedUrl = new URL(window.location.origin + window.location.pathname)
-        expectedUrl.searchParams.append('point', coordinateToText(point1.coordinate))
-        expectedUrl.searchParams.append('point', coordinateToText(point2.coordinate))
-        expectedUrl.searchParams.append('profile', profile)
-        expectedUrl.searchParams.append('layer', layer)
-
-        queryStore.receive(new SetPoint(point1))
-        queryStore.receive(new SetPoint(point2))
-        queryStore.receive(new SetVehicleProfile({ name: profile }))
-        mapStore.receive(new SelectMapStyle({ name: layer, url: '', type: 'vector', attribution: '' }))
-
-        // the nav bar component should use push state to set a new url
-        expect(window.history.pushState).toHaveBeenCalledTimes(4)
-        expect(window.history.pushState).toHaveBeenNthCalledWith(4, 'last state', '', expectedUrl.toString())
-    })
-
-    it('should parse the url and create a new query state when triggered from outside', () => {
-        // set up data
-        const point: QueryPoint = {
-            coordinate: { lat: 1, lng: 1 },
-            id: 0,
-            type: QueryPointType.To,
-            isInitialized: false,
-            queryText: '',
-            color: '',
-        }
-        const profile = 'some-profile'
-        const layer = 'Omniscale'
-        const url = new URL(window.location.origin + window.location.pathname)
-        url.searchParams.append('point', coordinateToText(point.coordinate))
-        url.searchParams.append('profile', profile)
-        url.searchParams.append('layer', layer)
-
-        window.location = {
-            ...window.location,
-            href: url.toString(),
-        }
-
-        const { queryStore, mapStore, navBar } = setUpFunctionality()
-
-        // act
-        navBar.parseUrlAndReplaceQuery()
-
-        //assert
-        expect(queryStore.state.queryPoints.length).toEqual(2)
-        expect(queryStore.state.queryPoints[0].coordinate).toEqual(point.coordinate)
-        expect(queryStore.state.queryPoints[0].isInitialized).toEqual(true)
-        expect(queryStore.state.queryPoints[1].coordinate).toEqual({ lat: 0, lng: 0 })
-        expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
-        expect(queryStore.state.routingProfile.name).toEqual(profile)
-
-        expect(mapStore.state.selectedStyle.name).toEqual(layer)
-
-        // make sure the navbar doesn't change the window's location while parsing
-        expect(url.toString()).toEqual(window.location.href)
-    })
-
-    it('should parse the url and set no points when no points are set', () => {
-        window.location = {
-            ...window.location,
-            href: 'https://origin.com',
-        }
-        const { queryStore, navBar } = setUpFunctionality()
-        const point1 = queryStore.state.queryPoints[0]
-        const point2 = queryStore.state.queryPoints[1]
-
-        // act
-        navBar.parseUrlAndReplaceQuery()
-
-        //assert
-        // we still want to have 2 points and they should have the same values as before - the ids are changed though
-        // since the store creates new instances of points regardless what is fed with "setallqyeryparamsatonce"
-        expect(queryStore.state.queryPoints.length).toEqual(2)
-        expect(queryStore.state.queryPoints[0].coordinate).toEqual(point1.coordinate)
-        expect(queryStore.state.queryPoints[1].coordinate).toEqual(point2.coordinate)
-        expect(queryStore.state.queryPoints[0].queryText).toEqual(point1.queryText)
-        expect(queryStore.state.queryPoints[1].queryText).toEqual(point2.queryText)
-    })
-
-    it('should parse the url and invalidate old points', () => {
-        window.location = {
-            ...window.location,
-            href: 'https://origin.com',
-        }
-        const { queryStore, navBar } = setUpFunctionality()
-        Dispatcher.dispatch(
-            new SetPoint({
-                ...queryStore.state.queryPoints[0],
-                isInitialized: true,
+    describe('state to url', () => {
+        it('should convert query store state into url params on change', function () {
+            const coordinates = [
+                { lat: 1, lng: 2 },
+                { lat: 10, lng: 10 },
+            ]
+            const points = coordinates.map((c, i) => {
+                return {
+                    ...queryStore.state.queryPoints[i],
+                    coordinate: c,
+                    queryText: coordinateToText(c),
+                    isInitialized: true,
+                }
             })
-        )
 
-        //act
-        navBar.parseUrlAndReplaceQuery()
+            testCreateUrl(
+                points,
+                { name: 'my-profile' },
+                { name: 'Lyrk', url: '', type: 'raster', attribution: '', maxZoom: 1 }
+            )
+        })
 
-        // assert
-        expect(queryStore.state.queryPoints.length).toEqual(2)
-        expect(queryStore.state.queryPoints[0].isInitialized).toBeFalsy()
-        expect(queryStore.state.queryPoints[1].isInitialized).toBeFalsy()
+        it('should convert query store state into url params on change including addresses', () => {
+            const points = [
+                { lat: 1, lng: 2, text: 'som3, address with ! some, characters-in it' },
+                { lat: 10, lng: 10, text: 'some_?more>characters' },
+            ].map((point, i) => {
+                return {
+                    ...queryStore.state.queryPoints[i],
+                    coordinate: { lat: point.lat, lng: point.lng },
+                    queryText: point.text,
+                    isInitialized: true,
+                }
+            })
+
+            testCreateUrl(
+                points,
+                { name: 'my-profile' },
+                { name: '', url: '', type: 'raster', attribution: '', maxZoom: 1 }
+            )
+        })
+
+        function testCreateUrl(points: QueryPoint[], profile: RoutingProfile, style: StyleOption) {
+            // build url which we expect at the end
+            const expectedUrl = new URL(window.location.origin + window.location.pathname)
+            for (const point of points) {
+                const coordinate = coordinateToText(point.coordinate)
+                const param = coordinate === point.queryText ? coordinate : coordinate + '_' + point.queryText
+                expectedUrl.searchParams.append('point', param)
+            }
+            expectedUrl.searchParams.append('profile', profile.name)
+            expectedUrl.searchParams.append('layer', style.name)
+
+            // modify state of stores which the nav bar depends on
+            for (const point of points) {
+                queryStore.receive(new SetPoint(point))
+            }
+            queryStore.receive(new SetVehicleProfile(profile))
+            mapStore.receive(new SelectMapStyle(style))
+
+            // make assertions
+            // number of calls profile, style and how many points there are
+            const numberOfCalls = 2 + points.length
+            expect(window.history.pushState).toHaveBeenCalledTimes(numberOfCalls)
+            expect(window.history.pushState).toHaveBeenNthCalledWith(
+                numberOfCalls,
+                'last state',
+                '',
+                expectedUrl.toString()
+            )
+        }
     })
 
-    it('should parse the url and set defaults for layer if not provided', () => {
-        window.location = {
-            ...window.location,
-            href: 'https://origin.com',
-        }
+    describe('url to state', () => {
+        it('should parse the url and create a new query state when triggered from outside', () => {
+            // set up data
+            const point: QueryPoint = {
+                coordinate: { lat: 1, lng: 1 },
+                id: 0,
+                type: QueryPointType.To,
+                isInitialized: false,
+                queryText: 'some1address-with!/<symb0ls',
+                color: '',
+            }
+            const profile = 'some-profile'
+            const layer = 'Omniscale'
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('point', coordinateToText(point.coordinate) + '_' + point.queryText)
+            url.searchParams.append('profile', profile)
+            url.searchParams.append('layer', layer)
 
-        const { queryStore, mapStore, navBar } = setUpFunctionality()
+            window.location = {
+                ...window.location,
+                href: url.toString(),
+            }
 
-        // act
-        navBar.parseUrlAndReplaceQuery()
+            // act
+            navBar.parseUrlAndReplaceQuery()
 
-        //assert
-        expect(queryStore.state.queryPoints.length).toEqual(2)
-        expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
-        expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
-        expect(queryStore.state.routingProfile.name).toEqual('')
+            //assert
+            expect(queryStore.state.queryPoints.length).toEqual(2)
+            expect(queryStore.state.queryPoints[0].coordinate).toEqual(point.coordinate)
+            expect(queryStore.state.queryPoints[0].isInitialized).toEqual(true)
+            expect(queryStore.state.queryPoints[0].queryText).toEqual(point.queryText)
+            expect(queryStore.state.queryPoints[1].coordinate).toEqual({ lat: 0, lng: 0 })
+            expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
+            expect(queryStore.state.routingProfile.name).toEqual(profile)
 
-        expect(mapStore.state.selectedStyle.name).toEqual(config.defaultTiles)
-    })
+            expect(mapStore.state.selectedStyle.name).toEqual(layer)
 
-    it('should parse the url and set defaults for profile if not set', () => {
-        const layername = 'Omniscale'
-        const url = new URL(window.location.origin + window.location.pathname)
-        url.searchParams.append('layer', layername)
-        window.location = {
-            ...window.location,
-            href: url.toString(),
-        }
+            // make sure the navbar doesn't change the window's location while parsing
+            expect(url.toString()).toEqual(window.location.href)
+        })
 
-        const { queryStore, mapStore, navBar } = setUpFunctionality()
-        Dispatcher.dispatch(new SetVehicleProfile({ name: 'some-profile' }))
-        const defaultProfile = queryStore.state.routingProfile
+        it('should parse the url and set no points when no points are set', () => {
+            window.location = {
+                ...window.location,
+                href: 'https://origin.com',
+            }
+            const point1 = queryStore.state.queryPoints[0]
+            const point2 = queryStore.state.queryPoints[1]
 
-        // act
-        navBar.parseUrlAndReplaceQuery()
+            // act
+            navBar.parseUrlAndReplaceQuery()
 
-        //assert
-        expect(queryStore.state.queryPoints.length).toEqual(2)
-        expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
-        expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
-        expect(queryStore.state.routingProfile.name).toEqual(defaultProfile.name)
-        expect(mapStore.state.selectedStyle.name).toEqual(layername)
-    })
+            //assert
+            // we still want to have 2 points and they should have the same values as before - the ids are changed though
+            // since the store creates new instances of points regardless what is fed with "setallqyeryparamsatonce"
+            expect(queryStore.state.queryPoints.length).toEqual(2)
+            expect(queryStore.state.queryPoints[0].coordinate).toEqual(point1.coordinate)
+            expect(queryStore.state.queryPoints[1].coordinate).toEqual(point2.coordinate)
+            expect(queryStore.state.queryPoints[0].queryText).toEqual(point1.queryText)
+            expect(queryStore.state.queryPoints[1].queryText).toEqual(point2.queryText)
+        })
 
-    it('should parse the url and set routing profile for legacy "vehicle" param', () => {
-        const layername = 'Omniscale'
-        const profileName = 'some-profile-name'
-        const url = new URL(window.location.origin + window.location.pathname)
-        url.searchParams.append('layer', layername)
-        url.searchParams.append('vehicle', profileName)
-        const { queryStore, navBar } = setUpFunctionality()
+        it('should parse the url and invalidate old points', () => {
+            window.location = {
+                ...window.location,
+                href: 'https://origin.com',
+            }
+            Dispatcher.dispatch(
+                new SetPoint({
+                    ...queryStore.state.queryPoints[0],
+                    isInitialized: true,
+                })
+            )
 
-        window.location = {
-            ...window.location,
-            href: url.toString(),
-        }
+            //act
+            navBar.parseUrlAndReplaceQuery()
 
-        // act
-        navBar.parseUrlAndReplaceQuery()
+            // assert
+            expect(queryStore.state.queryPoints.length).toEqual(2)
+            expect(queryStore.state.queryPoints[0].isInitialized).toBeFalsy()
+            expect(queryStore.state.queryPoints[1].isInitialized).toBeFalsy()
+        })
 
-        // assert
-        expect(queryStore.state.routingProfile.name).toEqual(profileName)
+        it('should parse the url and set defaults for layer if not provided', () => {
+            window.location = {
+                ...window.location,
+                href: 'https://origin.com',
+            }
+
+            // act
+            navBar.parseUrlAndReplaceQuery()
+
+            //assert
+            expect(queryStore.state.queryPoints.length).toEqual(2)
+            expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
+            expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
+            expect(queryStore.state.routingProfile.name).toEqual('')
+
+            expect(mapStore.state.selectedStyle.name).toEqual(config.defaultTiles)
+        })
+
+        it('should parse the url and set defaults for profile if not set', () => {
+            const layername = 'Omniscale'
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('layer', layername)
+            window.location = {
+                ...window.location,
+                href: url.toString(),
+            }
+
+            Dispatcher.dispatch(new SetVehicleProfile({ name: 'some-profile' }))
+            const defaultProfile = queryStore.state.routingProfile
+
+            // act
+            navBar.parseUrlAndReplaceQuery()
+
+            //assert
+            expect(queryStore.state.queryPoints.length).toEqual(2)
+            expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
+            expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
+            expect(queryStore.state.routingProfile.name).toEqual(defaultProfile.name)
+            expect(mapStore.state.selectedStyle.name).toEqual(layername)
+        })
+
+        it('should parse the url and set routing profile for legacy "vehicle" param', () => {
+            const layername = 'Omniscale'
+            const profileName = 'some-profile-name'
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('layer', layername)
+            url.searchParams.append('vehicle', profileName)
+
+            window.location = {
+                ...window.location,
+                href: url.toString(),
+            }
+
+            // act
+            navBar.parseUrlAndReplaceQuery()
+
+            // assert
+            expect(queryStore.state.routingProfile.name).toEqual(profileName)
+        })
     })
 
     it('should update the query store state on popstate (back-pressed)', () => {
-        const callbacks: { (type: string): void }[] = []
-        window.addEventListener = jest.fn((type: any, listener: any) => {
-            callbacks.push(listener)
-        })
-
         // set up data
         const point: QueryPoint = {
             coordinate: { lat: 1, lng: 1 },
@@ -249,8 +287,6 @@ describe('NavBar', function () {
             ...window.location,
             href: url.toString(),
         }
-
-        const { queryStore, mapStore } = setUpFunctionality()
 
         // act
         callbacks.forEach(callback => callback('popstate'))


### PR DESCRIPTION
fixes #10 

The addresses are written into the url inside the 'point' param. Separated from the coordinate with a '_' . I expect this character to appear in adresses not very often. The current approach handles a case where '_' would be part of an address by only parsing the part before the '_' character. 

Example URL: `http://localhost:3000/?point=52.464846%2C13.443016_Karl-Marx-Stra%C3%9Fe%2C+12057+Berlin%2C+Deutschland&profile=car&layer=OpenStreetMap`