### PR TITLE
Add launch.json from Vs-Code to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /dist/
 *~
 config-local.js
+#VS-Code Launch config
+launch.json


### PR DESCRIPTION
Vs-Code has the functionality to create a Launch config for a project for easier debugging and testing. As that is something which is per-user and shouldn't be uniformal to the entire project (as not everyone uses VS-Code as example), it should be part of the gitignore.