### PR TITLE
minor profile style fix

### DIFF
--- a/src/sidebar/search/routingProfiles/RoutingProfiles.modules.css
+++ b/src/sidebar/search/routingProfiles/RoutingProfiles.modules.css
@@ -4,7 +4,7 @@
     flex-direction: row;
     overflow-x: auto;
     overflow-y: hidden;
-    padding: 0.1em 0 0.1em 0.1em;
+    padding: 0.1em 0 0.1em 0.3em;
 }
 
 .profile:first-child {


### PR DESCRIPTION
The "outline" circle of the button is not fully visible on firefox and chromium. And on chromium it is black.
 
Before Firefox:

![image](https://user-images.githubusercontent.com/129644/175786082-20cffd1e-ed38-4720-b4f4-65f2a974f141.png)

After Firefox:

![image](https://user-images.githubusercontent.com/129644/175786060-8df6ee84-6976-4641-933b-daa88c25c2bc.png)

Before Chromium:

![image](https://user-images.githubusercontent.com/129644/175786112-ca950fac-da87-4baf-953d-27b1b6144da1.png)

After Chromium:

![image](https://user-images.githubusercontent.com/129644/175786148-19b6227d-24c5-4249-880c-415c95f941d4.png)

Unfortunately for Chromium the first profile is now even less aligned with the input. Not sure if this is worse and how to fix this. We could probably reduce `padding: 0.45rem;` again to reduce this problem but still it is no 100% fix.