### PR TITLE
Pass initial state to store constructor instead of overriding getInitialState

### DIFF
--- a/src/stores/ApiInfoStore.ts
+++ b/src/stores/ApiInfoStore.ts
@@ -4,7 +4,11 @@ import { InfoReceived } from '@/actions/Actions'
 import { ApiInfo } from '@/api/graphhopper'
 
 export default class ApiInfoStore extends Store<ApiInfo> {
-    protected getInitialState(): ApiInfo {
+    constructor() {
+        super(ApiInfoStore.getInitialState())
+    }
+
+    private static getInitialState(): ApiInfo {
         return {
             version: '',
             bbox: [0, 0, 0, 0],

--- a/src/stores/ErrorStore.ts
+++ b/src/stores/ErrorStore.ts
@@ -8,7 +8,11 @@ export interface ErrorStoreState {
 }
 
 export default class ErrorStore extends Store<ErrorStoreState> {
-    protected getInitialState(): ErrorStoreState {
+    constructor() {
+        super(ErrorStore.getInitialState())
+    }
+
+    private static getInitialState(): ErrorStoreState {
         return {
             isDismissed: true,
             lastError: '',

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -216,7 +216,11 @@ const styleOptions: StyleOption[] = [
 ]
 
 export default class MapOptionsStore extends Store<MapOptionsStoreState> {
-    protected getInitialState(): MapOptionsStoreState {
+    constructor() {
+        super(MapOptionsStore.getInitialState())
+    }
+
+    private static getInitialState(): MapOptionsStoreState {
         const selectedStyle = styleOptions.find(s => s.name === config.defaultTiles)
         if (!selectedStyle)
             console.warn(

--- a/src/stores/PathDetailsStore.ts
+++ b/src/stores/PathDetailsStore.ts
@@ -17,7 +17,11 @@ export interface PathDetailsStoreState {
 }
 
 export default class PathDetailsStore extends Store<PathDetailsStoreState> {
-    protected getInitialState(): PathDetailsStoreState {
+    constructor() {
+        super(PathDetailsStore.getInitialState())
+    }
+
+    private static getInitialState(): PathDetailsStoreState {
         return {
             pathDetailsPoint: null,
             pathDetailBbox: undefined,

--- a/src/stores/QueryStore.ts
+++ b/src/stores/QueryStore.ts
@@ -77,11 +77,11 @@ export default class QueryStore extends Store<QueryStoreState> {
     private readonly api: Api
 
     constructor(api: Api) {
-        super()
+        super(QueryStore.getInitialState())
         this.api = api
     }
 
-    protected getInitialState(): QueryStoreState {
+    private static getInitialState(): QueryStoreState {
         return {
             queryPoints: [
                 QueryStore.getEmptyPoint(0, QueryPointType.From),

--- a/src/stores/RouteStore.ts
+++ b/src/stores/RouteStore.ts
@@ -39,7 +39,7 @@ export default class RouteStore extends Store<RouteStoreState> {
     private readonly queryStore: QueryStore
 
     constructor(queryStore: QueryStore) {
-        super()
+        super(RouteStore.getInitialState())
         this.queryStore = queryStore
     }
 
@@ -57,12 +57,12 @@ export default class RouteStore extends Store<RouteStoreState> {
             action instanceof ClearPoints ||
             action instanceof RemovePoint
         ) {
-            return this.getInitialState()
+            return RouteStore.getInitialState()
         }
         return state
     }
 
-    protected getInitialState(): RouteStoreState {
+    private static getInitialState(): RouteStoreState {
         return {
             routingResult: {
                 paths: [],
@@ -84,7 +84,7 @@ export default class RouteStore extends Store<RouteStoreState> {
                 selectedPath: action.result.paths[0],
             }
         }
-        return this.getInitialState()
+        return RouteStore.getInitialState()
     }
 
     private isStaleRequest(request: RoutingArgs) {

--- a/src/stores/Store.ts
+++ b/src/stores/Store.ts
@@ -3,8 +3,8 @@ import { Action, ActionReceiver, NotifyStateChanged } from '@/stores/Dispatcher'
 export default abstract class Store<TState> implements ActionReceiver, NotifyStateChanged {
     private _subscriptions: { (): void }[] = []
 
-    constructor() {
-        this._state = this.getInitialState()
+    protected constructor(initialState: TState) {
+        this._state = initialState
     }
 
     private _state: TState
@@ -29,8 +29,6 @@ export default abstract class Store<TState> implements ActionReceiver, NotifySta
     deregister(callback: () => void): void {
         this._subscriptions = this._subscriptions.filter(s => s !== callback)
     }
-
-    protected abstract getInitialState(): TState
 
     abstract reduce(state: TState, action: Action): TState
 


### PR DESCRIPTION
So far we had:

```ts
abstract class Store<T> {
    constructor() {
        this._state = this.getInitialState()
    }
    abstract getInitialState() : T
}

class MyStore extends Store<MyState> {
    protected getInitialState() : MyStoreState {
        return { "my_name": "whatever"}
    }
}
```

But what if we did not want to hard-code `my_name` and instead be able to configure `my_name` via the `MyStore` constructor? Of course we would do:

```ts
class MyStore extends Store<MyState> {
    readonly myName: string
    constructor(myName: string) {
        this.myName = myName;
    }
    
     protected getInitialState() : MyStoreState {
        return { "my_name": this.myName}
    }
}
```

Yeah, looks good.
... except it does not work. Why? The `MyStore` constructor first calls the super constructor, which then calls `getInitialState`, but at this time the `MyStore` constructor has not completed yet, so `this.myName` is null. That is exactly the reason why protected methods should not be called in constructors, let alone in constructors of abstract classes where the called method is designed to be overriden.

The solution is simple here, especially because TypeScript allows calling stuff before calling the super constructor (other than Java): Just pass the state to the super constructor.

Let's say we want to parameterize the Store implementation
This way we can parameterize the stores by passing things to their constructors