### PR TITLE
Allow setting an initial custom model via an url parameter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,7 +124,11 @@ function LargeScreenLayout({ query, route, map, error, mapOptions, info }: Layou
                         selectedProfile={query.routingProfile}
                         autofocus={false}
                     />
-                    <CustomModelBox enabled={query.customModelEnabled} encodedValues={info.encoded_values} />
+                    <CustomModelBox
+                        enabled={query.customModelEnabled}
+                        encodedValues={info.encoded_values}
+                        initialCustomModelStr={query.initialCustomModelStr}
+                    />
                     <div>{!error.isDismissed && <ErrorMessage error={error} />}</div>
                     <div className={styles.routingResult}>
                         <RoutingResults

--- a/src/NavBar.ts
+++ b/src/NavBar.ts
@@ -29,6 +29,8 @@ export default class NavBar {
 
         result.searchParams.append('profile', queryStoreState.routingProfile.name)
         result.searchParams.append('layer', mapState.selectedStyle.name)
+        if (queryStoreState.customModelEnabled && queryStoreState.customModel && queryStoreState.customModelValid)
+            result.searchParams.append('custom_model', JSON.stringify(queryStoreState.customModel))
 
         return result
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,12 +25,16 @@ import { getApi, setApi } from '@/api/Api'
 import MapActionReceiver from '@/stores/MapActionReceiver'
 import { createMap, getMap, setMap } from '@/map/map'
 
-let locale = new URL(window.location.href).searchParams.get('locale')
+const url = new URL(window.location.href)
+const locale = url.searchParams.get('locale')
 setTranslation(locale || navigator.language)
 
-// set up state management
-setApi(config.api, getApiKey())
-const queryStore = new QueryStore(getApi())
+// use graphhopper api key from url or try using one from the config
+const apiKey = url.searchParams.has('key') ? url.searchParams.get('key') : config.keys.graphhopper
+setApi(config.api, apiKey)
+
+const initialCustomModelStr = url.searchParams.get('custom_model')
+const queryStore = new QueryStore(getApi(), initialCustomModelStr)
 const routeStore = new RouteStore(queryStore)
 
 setStores({
@@ -71,9 +75,3 @@ root.style.height = '100%'
 document.body.appendChild(root)
 
 ReactDOM.render(<App />, root)
-
-function getApiKey() {
-    const url = new URL(window.location.href)
-    // use graphhopper api key from url or try using one from the config
-    return url.searchParams.has('key') ? url.searchParams.get('key') : config.keys.graphhopper
-}

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -78,6 +78,7 @@ export default function CustomModelBox({ enabled, encodedValues, initialCustomMo
         const instance = create({}, (element: Node) => divElement.current?.appendChild(element))
         setEditor(instance)
 
+        instance.cm.setSize('100%', '100%')
         if (initialCustomModelStr != null) {
             // prettify the custom model if it can be parsed or leave it as is otherwise
             try {
@@ -92,10 +93,6 @@ export default function CustomModelBox({ enabled, encodedValues, initialCustomMo
             setIsValid(valid)
         }
     }, [])
-
-    useEffect(() => {
-        editor?.cm.setSize('100%', '100%')
-    }, [enabled])
 
     useEffect(() => {
         if (!editor) return

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -94,9 +94,8 @@ export default function CustomModelBox({ enabled, encodedValues, initialCustomMo
         }
     }, [])
 
-    useEffect(() => {
-        editor?.cm.setSize('100%', '100%')
-    }, [enabled])
+    // without this the editor is blank after opening the box and before clicking it or resizing the window?
+    editor?.cm.setSize('100%', '100%')
 
     useEffect(() => {
         if (!editor) return

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -95,6 +95,7 @@ export default function CustomModelBox({ enabled, encodedValues, initialCustomMo
     }, [])
 
     // without this the editor is blank after opening the box and before clicking it or resizing the window?
+    // but having the focus in the box after opening it is nice anyway
     useEffect(() => {
         if (enabled) editor?.cm.focus()
     }, [enabled])

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -95,6 +95,10 @@ export default function CustomModelBox({ enabled, encodedValues, initialCustomMo
     }, [])
 
     useEffect(() => {
+        editor?.cm.setSize('100%', '100%')
+    }, [enabled])
+
+    useEffect(() => {
         if (!editor) return
 
         // todo: maybe do this 'conversion' in Api.ts already and use types from there on

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -64,9 +64,10 @@ const examples: { [key: string]: CustomModel } = {
 export interface CustomModelBoxProps {
     enabled: boolean
     encodedValues: object[]
+    initialCustomModelStr: string | null
 }
 
-export default function CustomModelBox({ enabled, encodedValues }: CustomModelBoxProps) {
+export default function CustomModelBox({ enabled, encodedValues, initialCustomModelStr }: CustomModelBoxProps) {
     // todo: add types for custom model editor later
     const [editor, setEditor] = useState<any>()
     const [isValid, setIsValid] = useState(false)
@@ -76,9 +77,16 @@ export default function CustomModelBox({ enabled, encodedValues }: CustomModelBo
         // we start with empty categories. they will be set later using info
         const instance = create({}, (element: Node) => divElement.current?.appendChild(element))
         setEditor(instance)
-        setCustomModelExample(instance, examples['empty'])
-        // todo: minor glitch: if the initial model is invalid we see an 'Invalid custom model' error notification, even
-        //       though the custom model box is closed initially
+
+        if (initialCustomModelStr != null) {
+            // prettify the custom model if it can be parsed or leave it as is otherwise
+            try {
+                initialCustomModelStr = customModel2prettyString(JSON.parse(initialCustomModelStr))
+            } catch (e) {}
+        }
+        instance.value =
+            initialCustomModelStr == null ? customModel2prettyString(examples['empty']) : initialCustomModelStr
+
         instance.validListener = (valid: boolean) => {
             dispatchCustomModel(instance.value, valid)
             setIsValid(valid)
@@ -118,10 +126,6 @@ export default function CustomModelBox({ enabled, encodedValues }: CustomModelBo
         [editor, isValid]
     )
 
-    const setCustomModelExample = (editor: any, customModelExample: CustomModel) => {
-        editor.value = JSON.stringify(customModelExample, null, 2)
-    }
-
     return (
         <>
             <PlainButton
@@ -154,7 +158,8 @@ export default function CustomModelBox({ enabled, encodedValues }: CustomModelBo
                     <select
                         className={styles.examples}
                         onChange={(e: any) => {
-                            setCustomModelExample(editor, examples[e.target.value])
+                            editor.value = customModel2prettyString(examples[e.target.value])
+                            // when selecting an example we fire a request no matter if the model is valid or not
                             dispatchCustomModel(JSON.stringify(examples[e.target.value]), true, true)
                         }}
                     >
@@ -184,4 +189,8 @@ function dispatchCustomModel(customModelValue: any, isValid: boolean, withRouteR
         Dispatcher.dispatch(new ErrorAction('Cannot parse custom model'))
         Dispatcher.dispatch(new SetCustomModel(null, false, withRouteRequest))
     }
+}
+
+function customModel2prettyString(customModel: CustomModel) {
+    return JSON.stringify(customModel, null, 2)
 }

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -95,7 +95,9 @@ export default function CustomModelBox({ enabled, encodedValues, initialCustomMo
     }, [])
 
     // without this the editor is blank after opening the box and before clicking it or resizing the window?
-    editor?.cm.setSize('100%', '100%')
+    useEffect(() => {
+        if (enabled) editor?.cm.focus()
+    }, [enabled])
 
     useEffect(() => {
         if (!editor) return

--- a/src/sidebar/RoutingResults.tsx
+++ b/src/sidebar/RoutingResults.tsx
@@ -9,7 +9,7 @@ import PlainButton from '@/PlainButton'
 import Arrow from '@/sidebar/chevron-down-solid.svg'
 import Instructions from '@/sidebar/instructions/Instructions'
 import { useMediaQuery } from 'react-responsive'
-import {tr} from "@/translation/Translation";
+import { tr } from '@/translation/Translation'
 
 export interface RoutingResultsProps {
     paths: Path[]
@@ -38,7 +38,11 @@ function RoutingResult({ path, isSelected }: { path: Path; isSelected: boolean }
                     <div className={styles.resultValues}>
                         <span className={styles.resultMainText}>{milliSecondsToText(path.time)}</span>
                         <span className={styles.resultSecondaryText}>{metersToText(path.distance)}</span>
-                        {path.description && <span className={styles.resultTertiaryText}>{tr("Via")} {path.description}</span>}
+                        {path.description && (
+                            <span className={styles.resultTertiaryText}>
+                                {tr('Via')} {path.description}
+                            </span>
+                        )}
                     </div>
                     {isSelected && (
                         <PlainButton className={buttonClass} onClick={() => setExpanded(!isExpanded)}>

--- a/src/stores/QueryStore.ts
+++ b/src/stores/QueryStore.ts
@@ -34,6 +34,8 @@ export interface QueryStoreState {
     readonly customModel: CustomModel | null
     // todo: probably this should go somewhere else, see: https://github.com/graphhopper/graphhopper-maps/pull/193
     readonly zoom: boolean
+    // todo: ... and this also
+    readonly initialCustomModelStr: string | null
 }
 
 export interface QueryPoint {
@@ -76,12 +78,12 @@ export interface SubRequest {
 export default class QueryStore extends Store<QueryStoreState> {
     private readonly api: Api
 
-    constructor(api: Api) {
-        super(QueryStore.getInitialState())
+    constructor(api: Api, initialCustomModelStr: string | null = null) {
+        super(QueryStore.getInitialState(initialCustomModelStr))
         this.api = api
     }
 
-    private static getInitialState(): QueryStoreState {
+    private static getInitialState(initialCustomModelStr: string | null): QueryStoreState {
         return {
             queryPoints: [
                 QueryStore.getEmptyPoint(0, QueryPointType.From),
@@ -95,10 +97,11 @@ export default class QueryStore extends Store<QueryStoreState> {
             routingProfile: {
                 name: '',
             },
-            customModelEnabled: false,
+            customModelEnabled: initialCustomModelStr != null,
             customModelValid: false,
             customModel: null,
             zoom: true,
+            initialCustomModelStr: initialCustomModelStr,
         }
     }
 

--- a/src/stores/RouteStore.ts
+++ b/src/stores/RouteStore.ts
@@ -33,7 +33,7 @@ export default class RouteStore extends Store<RouteStoreState> {
             distance: 0,
             points_order: [],
             time: 0,
-            description: "",
+            description: '',
         }
     }
 


### PR DESCRIPTION
For #206 

With this PR we can append an arbitrary string (but better a valid custom model json string) via `&custom_model={"whatever": "here"}` to the url. This will start the app with an open custom model box containing this string.