### PR TITLE
Add routing graph layer

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,6 +14,8 @@ module.exports = {
         thunderforest: "missing_api_key",
         kurviger: "missing_api_key"
     },
+    // if true there will be an option to enable the GraphHopper routing graph in the layers menu
+    routingGraphLayerAllowed: false,
     // use this to add your own profiles. the key of each profile will be used as name and the given fields will
     // overwrite the fields of the default routing request. e.g.
     // extraProfiles: { my_car: { profile: undefined, vehicle: car }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import styles from './App.module.css'
 import {
     getApiInfoStore,
     getErrorStore,
+    getMapFeatureStore,
     getMapOptionsStore,
     getPathDetailsStore,
     getQueryStore,
@@ -32,6 +33,7 @@ import { Map } from 'ol'
 import { getMap } from '@/map/map'
 import CustomModelBox from '@/sidebar/CustomModelBox'
 import useRoutingGraphLayer from '@/layers/UseRoutingGraphLayer'
+import MapFeaturePopup from '@/layers/MapFeaturePopup'
 
 export const POPUP_CONTAINER_ID = 'popup-container'
 export const SIDEBAR_CONTENT_ID = 'sidebar-content'
@@ -43,6 +45,7 @@ export default function App() {
     const [error, setError] = useState(getErrorStore().state)
     const [mapOptions, setMapOptions] = useState(getMapOptionsStore().state)
     const [pathDetails, setPathDetails] = useState(getPathDetailsStore().state)
+    const [mapFeatures, setMapFeatures] = useState(getMapFeatureStore().state)
 
     const map = getMap()
 
@@ -53,6 +56,7 @@ export default function App() {
         const onErrorChanged = () => setError(getErrorStore().state)
         const onMapOptionsChanged = () => setMapOptions(getMapOptionsStore().state)
         const onPathDetailsChanged = () => setPathDetails(getPathDetailsStore().state)
+        const onMapFeaturesChanged = () => setMapFeatures(getMapFeatureStore().state)
 
         getQueryStore().register(onQueryChanged)
         getApiInfoStore().register(onInfoChanged)
@@ -60,6 +64,7 @@ export default function App() {
         getErrorStore().register(onErrorChanged)
         getMapOptionsStore().register(onMapOptionsChanged)
         getPathDetailsStore().register(onPathDetailsChanged)
+        getMapFeatureStore().register(onMapFeaturesChanged)
 
         return () => {
             getQueryStore().deregister(onQueryChanged)
@@ -68,6 +73,7 @@ export default function App() {
             getErrorStore().deregister(onErrorChanged)
             getMapOptionsStore().deregister(onMapOptionsChanged)
             getPathDetailsStore().deregister(onPathDetailsChanged)
+            getMapFeatureStore().deregister(onMapFeaturesChanged)
         }
     })
 
@@ -83,6 +89,7 @@ export default function App() {
         <div className={styles.appWrapper}>
             <PathDetailPopup map={map} pathDetails={pathDetails} />
             <ContextMenu map={map} route={route} queryPoints={query.queryPoints} />
+            <MapFeaturePopup map={map} point={mapFeatures.point} properties={mapFeatures.properties} />
             {isSmallScreen ? (
                 <SmallScreenLayout
                     query={query}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import PathDetailPopup from '@/layers/PathDetailPopup'
 import { Map } from 'ol'
 import { getMap } from '@/map/map'
 import CustomModelBox from '@/sidebar/CustomModelBox'
+import useRoutingGraphLayer from '@/layers/UseRoutingGraphLayer'
 
 export const POPUP_CONTAINER_ID = 'popup-container'
 export const SIDEBAR_CONTENT_ID = 'sidebar-content'
@@ -72,6 +73,7 @@ export default function App() {
 
     // our different map layers
     useBackgroundLayer(map, mapOptions.selectedStyle)
+    useRoutingGraphLayer(map, mapOptions.routingGraphEnabled)
     usePathsLayer(map, route.routingResult.paths, route.selectedPath)
     useQueryPointsLayer(map, query.queryPoints)
     usePathDetailsLayer(map, pathDetails)

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -188,3 +188,13 @@ export class PathDetailsElevationSelected implements Action {
         this.segments = segments
     }
 }
+
+export class RoutingGraphHover implements Action {
+    readonly point: Coordinate | null
+    readonly properties: object
+
+    constructor(point: Coordinate | null, properties: object) {
+        this.point = point
+        this.properties = properties
+    }
+}

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -137,6 +137,14 @@ export class SelectMapStyle implements Action {
     }
 }
 
+export class ToggleRoutingGraph implements Action {
+    readonly routingGraphEnabled: boolean
+
+    constructor(routingGraphEnabled: boolean) {
+        this.routingGraphEnabled = routingGraphEnabled
+    }
+}
+
 export class MapIsLoaded implements Action {}
 
 export class ZoomMapToPoint implements Action {

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -14,6 +14,7 @@ declare module 'config' {
         thunderforest: string,
         kurviger: string,
     }
+    const routingGraphLayerAllowed: boolean
     const extraProfiles: object
 }
 declare module 'react-responsive' {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import {
     getErrorStore,
     getMapOptionsStore,
     getPathDetailsStore,
+    getMapFeatureStore,
     getQueryStore,
     getRouteStore,
     setStores,
@@ -24,6 +25,7 @@ import * as config from 'config'
 import { getApi, setApi } from '@/api/Api'
 import MapActionReceiver from '@/stores/MapActionReceiver'
 import { createMap, getMap, setMap } from '@/map/map'
+import MapFeatureStore from '@/stores/MapFeatureStore'
 
 let locale = new URL(window.location.href).searchParams.get('locale')
 setTranslation(locale || navigator.language)
@@ -40,6 +42,7 @@ setStores({
     errorStore: new ErrorStore(),
     mapOptionsStore: new MapOptionsStore(),
     pathDetailsStore: new PathDetailsStore(),
+    mapFeatureStore: new MapFeatureStore(),
 })
 
 setMap(createMap())
@@ -51,6 +54,7 @@ Dispatcher.register(getApiInfoStore())
 Dispatcher.register(getErrorStore())
 Dispatcher.register(getMapOptionsStore())
 Dispatcher.register(getPathDetailsStore())
+Dispatcher.register(getMapFeatureStore())
 
 // register map action receiver
 const smallScreenMediaQuery = window.matchMedia('(max-width: 44rem)')

--- a/src/layers/MapFeaturePopup.module.css
+++ b/src/layers/MapFeaturePopup.module.css
@@ -1,0 +1,7 @@
+.popup {
+    background-color: white;
+    font-size: small;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+    padding: 5px 10px 5px 10px;
+    border-radius: 10px;
+}

--- a/src/layers/MapFeaturePopup.tsx
+++ b/src/layers/MapFeaturePopup.tsx
@@ -1,0 +1,42 @@
+import { Map, Overlay } from 'ol'
+import React, { useEffect, useRef, useState } from 'react'
+import styles from '@/layers/MapFeaturePopup.module.css'
+import { fromLonLat } from 'ol/proj'
+import { Coordinate } from '@/stores/QueryStore'
+
+interface MapFeaturePopupProps {
+    map: Map
+    point: Coordinate | null
+    properties: object
+}
+
+/**
+ * The popup shown when certain map features are hovered. For example a road of the routing graph layer.
+ */
+export default function MapFeaturePopup({ map, point, properties }: MapFeaturePopupProps) {
+    const [overlay, setOverlay] = useState<Overlay | undefined>()
+    const container = useRef<HTMLDivElement | null>()
+
+    useEffect(() => {
+        const overlay = new Overlay({
+            element: container.current!,
+            autoPan: false,
+        })
+        setOverlay(overlay)
+        map.addOverlay(overlay)
+    }, [map])
+
+    useEffect(() => {
+        overlay?.setPosition(point ? fromLonLat([point.lng, point.lat]) : undefined)
+    }, [point])
+
+    return (
+        <div className={styles.popup} ref={container as any}>
+            <ul>
+                {Object.entries(properties).map(([k, v], index) => {
+                    return <li key={index}>{`${k}=${v}`}</li>
+                })}
+            </ul>
+        </div>
+    )
+}

--- a/src/layers/UsePathsLayer.tsx
+++ b/src/layers/UsePathsLayer.tsx
@@ -11,6 +11,7 @@ import { Select } from 'ol/interaction'
 import { click } from 'ol/events/condition'
 import Dispatcher from '@/stores/Dispatcher'
 import { SetSelectedPath } from '@/actions/Actions'
+import { SelectEvent } from 'ol/interaction/Select'
 
 const pathsLayerKey = 'pathsLayer'
 const selectedPathLayerKey = 'selectedPathLayer'
@@ -64,8 +65,8 @@ function addUnselectedPathsLayer(map: Map, paths: Path[]) {
         style: null,
         hitTolerance: 5,
     })
-    select.on('select', e => {
-        const index = (e as any).selected[0].getProperties().index
+    select.on('select', (e: SelectEvent) => {
+        const index = e.selected[0].getProperties().index
         Dispatcher.dispatch(new SetSelectedPath(paths[index]))
     })
     select.set('gh:select_path_interaction', true)

--- a/src/layers/UseRoutingGraphLayer.tsx
+++ b/src/layers/UseRoutingGraphLayer.tsx
@@ -1,0 +1,71 @@
+import { Feature, Map } from 'ol'
+import React, { useEffect } from 'react'
+import VectorTileSource from 'ol/source/VectorTile'
+import VectorTileLayer from 'ol/layer/VectorTile'
+import { MVT } from 'ol/format'
+import * as config from 'config'
+import { Stroke, Style } from 'ol/style'
+
+const routingGraphLayerKey = 'routingGraphLayer'
+
+export default function useRoutingGraphLayer(map: Map, routingGraphEnabled: boolean) {
+    useEffect(() => {
+        removeRoutingGraphLayer(map)
+        if (routingGraphEnabled) addRoutingGraphLayer(map)
+        return () => {
+            removeRoutingGraphLayer(map)
+        }
+    }, [map, routingGraphEnabled])
+}
+
+function getStyle(feature: Feature, zoom: number): Style | undefined {
+    if (feature.get('layer') === 'roads') {
+        const roadClass = feature.get('road_class')
+        let color = '#aaa5a7'
+        let width = 1
+        if (roadClass === 'motorway') {
+            color = '#dd504b'
+            width = 3
+        } else if (roadClass === 'primary' || roadClass === 'trunk') {
+            color = '#e2a012'
+            width = 2
+        } else if (roadClass === 'secondary') {
+            color = '#f7c913'
+            width = 2
+        }
+        if (zoom > 16) width += 3
+        else if (zoom > 15) width += 2
+        else if (zoom > 13) width += 1
+        return new Style({
+            stroke: new Stroke({
+                color: color,
+                width: width,
+            }),
+        })
+    } else {
+        // do not render this feature
+        return undefined
+    }
+}
+
+function addRoutingGraphLayer(map: Map) {
+    const routingGraphLayer = new VectorTileLayer({
+        declutter: true,
+        source: new VectorTileSource({
+            attributions: '',
+            format: new MVT(),
+            url: `${config.api}mvt/{z}/{x}/{y}.mvt?details=road_class&details=surface&details=road_environment&details=max_speed&details=average_speed`,
+        }),
+        style: ((feature: Feature, resolution: number) =>
+            getStyle(feature, map.getView().getZoomForResolution(resolution)!)) as any,
+    })
+    routingGraphLayer.set(routingGraphLayerKey, true)
+    map.addLayer(routingGraphLayer)
+}
+
+function removeRoutingGraphLayer(map: Map) {
+    map.getLayers()
+        .getArray()
+        .filter(l => l.get(routingGraphLayerKey))
+        .forEach(l => map.removeLayer(l))
+}

--- a/src/layers/UseRoutingGraphLayer.tsx
+++ b/src/layers/UseRoutingGraphLayer.tsx
@@ -66,6 +66,10 @@ function addRoutingGraphLayer(map: Map) {
             getStyle(feature, map.getView().getZoomForResolution(resolution)!)) as any,
     })
     routingGraphLayer.set(routingGraphLayerKey, true)
+    // make sure the routing graph layer is shown on top of the background layer, but note that this also means it is
+    // on top of the vector layer text labels (for now I don't really care). the layer order is determined by both the
+    // z-index and the order of the layers in map.getLayers()
+    routingGraphLayer.setZIndex(0.5)
     map.addLayer(routingGraphLayer)
 
     const hover = new Select({

--- a/src/map/MapOptions.tsx
+++ b/src/map/MapOptions.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react'
 import styles from './MapOptions.modules.css'
 import { MapOptionsStoreState, StyleOption } from '@/stores/MapOptionsStore'
 import Dispatcher from '@/stores/Dispatcher'
-import { SelectMapStyle } from '@/actions/Actions'
+import { SelectMapStyle, ToggleRoutingGraph } from '@/actions/Actions'
 import PlainButton from '@/PlainButton'
 import LayerImg from './layer-group-solid.svg'
+import * as config from 'config'
 
 export default function (props: MapOptionsStoreState) {
     const [isOpen, setIsOpen] = useState(false)
@@ -32,32 +33,49 @@ interface OptionsProps {
 
 const Options = function ({ storeState, notifyChanged }: OptionsProps) {
     return (
-        <div
-            className={styles.options}
-            onChange={e => {
-                notifyChanged()
-                onChange(e.target as HTMLInputElement, storeState.styleOptions)
-            }}
-        >
-            {storeState.styleOptions.map(option => (
-                <div className={styles.option} key={option.name}>
+        <div className={styles.options}>
+            <div
+                onChange={e => {
+                    notifyChanged()
+                    onStyleChange(e.target as HTMLInputElement, storeState.styleOptions)
+                }}
+            >
+                {storeState.styleOptions.map(option => (
+                    <div className={styles.option} key={option.name}>
+                        <input
+                            type="radio"
+                            id={option.name}
+                            name="layer"
+                            value={option.name}
+                            defaultChecked={option === storeState.selectedStyle}
+                            disabled={!storeState.isMapLoaded}
+                        />
+                        <label htmlFor={option.name}>
+                            {option.name + (option.type === 'vector' ? ' (Vector)' : '')}
+                        </label>
+                    </div>
+                ))}
+            </div>
+            {config.routingGraphLayerAllowed && (
+                <div>
                     <input
-                        type="radio"
-                        id={option.name}
-                        name="layer"
-                        value={option.name}
-                        defaultChecked={option === storeState.selectedStyle}
-                        disabled={!storeState.isMapLoaded}
+                        type="checkbox"
+                        name="routing-graph"
+                        defaultChecked={storeState.routingGraphEnabled}
+                        disabled={false}
+                        onChange={e => {
+                            notifyChanged()
+                            Dispatcher.dispatch(new ToggleRoutingGraph(e.target.checked))
+                        }}
                     />
-                    <label htmlFor={option.name}>{option.name + (option.type === 'vector' ? ' (Vector)' : '')}</label>
+                    <label htmlFor="routing-graph">Show Routing Graph</label>
                 </div>
-            ))}
+            )}
         </div>
     )
 }
 
-function onChange(target: HTMLInputElement, options: StyleOption[]) {
+function onStyleChange(target: HTMLInputElement, options: StyleOption[]) {
     const option = options.find(option => option.name === target.value)
-
     if (option) Dispatcher.dispatch(new SelectMapStyle(option))
 }

--- a/src/map/MapOptions.tsx
+++ b/src/map/MapOptions.tsx
@@ -60,15 +60,14 @@ const Options = function ({ storeState, notifyChanged }: OptionsProps) {
                 <div>
                     <input
                         type="checkbox"
-                        name="routing-graph"
-                        defaultChecked={storeState.routingGraphEnabled}
-                        disabled={false}
+                        id="routing-graph-checkbox"
+                        checked={storeState.routingGraphEnabled}
                         onChange={e => {
                             notifyChanged()
                             Dispatcher.dispatch(new ToggleRoutingGraph(e.target.checked))
                         }}
                     />
-                    <label htmlFor="routing-graph">Show Routing Graph</label>
+                    <label htmlFor="routing-graph-checkbox">Show Routing Graph</label>
                 </div>
             )}
         </div>

--- a/src/stores/MapFeatureStore.ts
+++ b/src/stores/MapFeatureStore.ts
@@ -1,0 +1,29 @@
+import Store from '@/stores/Store'
+import { Action } from '@/stores/Dispatcher'
+import { RoutingGraphHover } from '@/actions/Actions'
+import { Coordinate } from '@/stores/QueryStore'
+
+export interface MapFeatureStoreState {
+    point: Coordinate | null
+    properties: object
+}
+
+export default class MapFeatureStore extends Store<MapFeatureStoreState> {
+    constructor() {
+        super({
+            point: null,
+            properties: {},
+        })
+    }
+
+    reduce(state: MapFeatureStoreState, action: Action): MapFeatureStoreState {
+        if (action instanceof RoutingGraphHover) {
+            return {
+                ...state,
+                point: action.point,
+                properties: action.properties,
+            }
+        }
+        return state
+    }
+}

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -1,6 +1,6 @@
 import Store from '@/stores/Store'
 import { Action } from '@/stores/Dispatcher'
-import { MapIsLoaded, SelectMapStyle } from '@/actions/Actions'
+import { MapIsLoaded, SelectMapStyle, ToggleRoutingGraph } from '@/actions/Actions'
 import config from 'config'
 
 const osApiKey = config.keys.omniscale
@@ -15,6 +15,7 @@ export interface MapOptionsStoreState {
     styleOptions: StyleOption[]
     selectedStyle: StyleOption
     isMapLoaded: boolean
+    routingGraphEnabled: boolean
 }
 
 export interface StyleOption {
@@ -229,6 +230,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
         return {
             selectedStyle: selectedStyle ? selectedStyle : omniscale,
             styleOptions,
+            routingGraphEnabled: false,
             isMapLoaded: false,
         }
     }
@@ -238,6 +240,11 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
             return {
                 ...state,
                 selectedStyle: action.styleOption,
+            }
+        } else if (action instanceof ToggleRoutingGraph) {
+            return {
+                ...state,
+                routingGraphEnabled: action.routingGraphEnabled,
             }
         } else if (action instanceof MapIsLoaded) {
             return {

--- a/src/stores/Stores.ts
+++ b/src/stores/Stores.ts
@@ -4,6 +4,7 @@ import ApiInfoStore from '@/stores/ApiInfoStore'
 import ErrorStore from '@/stores/ErrorStore'
 import MapOptionsStore from '@/stores/MapOptionsStore'
 import PathDetailsStore from '@/stores/PathDetailsStore'
+import MapFeatureStore from '@/stores/MapFeatureStore'
 
 let queryStore: QueryStore
 let routeStore: RouteStore
@@ -11,6 +12,7 @@ let infoStore: ApiInfoStore
 let errorStore: ErrorStore
 let mapOptionsStore: MapOptionsStore
 let pathDetailsStore: PathDetailsStore
+let mapFeatureStore: MapFeatureStore
 
 interface StoresInput {
     queryStore: QueryStore
@@ -19,6 +21,7 @@ interface StoresInput {
     errorStore: ErrorStore
     mapOptionsStore: MapOptionsStore
     pathDetailsStore: PathDetailsStore
+    mapFeatureStore: MapFeatureStore
 }
 
 export const setStores = function (stores: StoresInput) {
@@ -28,6 +31,7 @@ export const setStores = function (stores: StoresInput) {
     errorStore = stores.errorStore
     mapOptionsStore = stores.mapOptionsStore
     pathDetailsStore = stores.pathDetailsStore
+    mapFeatureStore = stores.mapFeatureStore
 }
 
 export const getQueryStore = () => queryStore
@@ -36,3 +40,4 @@ export const getApiInfoStore = () => infoStore
 export const getErrorStore = () => errorStore
 export const getMapOptionsStore = () => mapOptionsStore
 export const getPathDetailsStore = () => pathDetailsStore
+export const getMapFeatureStore = () => mapFeatureStore


### PR DESCRIPTION
Fixes #24.

Should be quite similar to what we had in GH maps 1. Maybe the biggest difference is that I put the road details into popup shown on top of the map. To enable the feature we need to set `routingGraphLayerAllowed: true` in `config-local.js`.

The popup looks like this currently: 

![image](https://user-images.githubusercontent.com/17603532/188310914-2ab38e21-fdd1-483b-8dce-301e1aaf60f3.png)
