### PR TITLE
Close context menu when we click the map

### DIFF
--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -45,7 +45,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchmove', () => longTouchHandler.onTouchEnd())
             map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
 
-            map.getTargetElement().addEventListener('click', () => {
+            map.on('click', () => {
                 overlay?.setPosition(undefined)
                 // setMenuCoordinate(null)
             })

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -41,6 +41,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             // the map container instead
             // https://github.com/openlayers/openlayers/issues/12512#issuecomment-879403189
             map.getTargetElement().addEventListener('contextmenu', openContextMenu)
+
             map.getTargetElement().addEventListener('touchstart', e => touchHandler.onTouchStart(e))
             map.getTargetElement().addEventListener('touchmove', e => touchHandler.onTouchMove(e))
             map.getTargetElement().addEventListener('touchend', e => touchHandler.onTouchEnd(e))
@@ -79,6 +80,7 @@ class TouchHandler {
 
     private touchStartEvent?: any
     private currentTimeout: number = 0
+    ongoing: boolean = false
 
     constructor(onLongTouch: (e: any) => void) {
         this.onLongTouch = onLongTouch
@@ -87,19 +89,19 @@ class TouchHandler {
     onTouchStart(e: any) {
         this.touchStartEvent = e
         this.currentTimeout = window.setTimeout(() => {
-            if (this.touchStartEvent) {
+            if (this.ongoing) {
                 this.onLongTouch(this.touchStartEvent)
+                this.ongoing = false
             }
         }, 500)
+        this.ongoing = true
     }
 
     onTouchMove(e: any) {
         window.clearTimeout(this.currentTimeout)
-        this.touchStartEvent = undefined
     }
 
     onTouchEnd(e: any) {
         window.clearTimeout(this.currentTimeout)
-        this.touchStartEvent = undefined
     }
 }

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -40,8 +40,6 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
                 overlay?.setPosition(undefined)
                 setMenuCoordinate(null)
             },
-            // on drag
-            () => {},
             // on long press
             e => {
                 openContextMenu(e)
@@ -106,19 +104,14 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
 // See #229
 class TouchHandler {
     private readonly onTap: () => void
-    private readonly onDrag: () => void
     private readonly onLongTouch: (e: any) => void
 
     private touchStartEvent?: any
     private currentTimeout: number = 0
-    private pageX: number = 0
-    private pageY: number = 0
-    private moved: boolean = false
     private ongoing: boolean = false
 
-    constructor(onTap: () => void, onDrag: () => void, onLongTouch: (e: any) => void) {
+    constructor(onTap: () => void, onLongTouch: (e: any) => void) {
         this.onTap = onTap
-        this.onDrag = onDrag
         this.onLongTouch = onLongTouch
     }
 
@@ -130,25 +123,18 @@ class TouchHandler {
                 this.ongoing = false
             }
         }, 500)
-        this.pageX = e.pageX
-        this.pageY = e.pageY
-        this.moved = false
         this.ongoing = true
     }
 
     onTouchMove(e: any) {
-        if (Math.abs(e.pageX - this.pageX) > 5 || Math.abs(e.pageY - this.pageY) > 5) {
-            this.moved = true
-            window.clearTimeout(this.currentTimeout)
-        }
+        window.clearTimeout(this.currentTimeout)
+        this.ongoing = false
     }
 
     onTouchEnd(e: any) {
         window.clearTimeout(this.currentTimeout)
-        if (!this.ongoing)
-            return
-        if (this.moved) this.onDrag()
-        else this.onTap()
+        if (this.ongoing)
+            this.onTap()
         this.ongoing = false
     }
 }

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -46,8 +46,10 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
 
             map.on('click', () => {
-                overlay?.setPosition(undefined)
-                setMenuCoordinate(null)
+                if (!longTouchHandler.currentEvent) {
+                    overlay?.setPosition(undefined)
+                    setMenuCoordinate(null)
+                }
             })
         })
 
@@ -77,7 +79,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
 class LongTouchHandler {
     private readonly callback: (e: any) => void
     private currentTimeout: number = 0
-    private currentEvent?: any
+    currentEvent?: any
 
     constructor(onLongTouch: (e: any) => void) {
         this.callback = onLongTouch

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -46,7 +46,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
 
             map.on('click', () => {
-                if (!longTouchHandler.currentEvent) {
+                if (menuCoordinate) {
                     overlay?.setPosition(undefined)
                     setMenuCoordinate(null)
                 }

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -34,16 +34,29 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             overlay.setPosition(coordinate)
         }
 
-        const longTouchHandler = new LongTouchHandler(e => openContextMenu(e))
+        const touchHandler = new TouchHandler(
+            // on tap
+            () => {
+                overlay?.setPosition(undefined)
+                setMenuCoordinate(null)
+            },
+            // on drag
+            () => {},
+            // on long press
+            e => {
+                openContextMenu(e)
+            }
+        )
 
         map.once('change:target', () => {
             // we cannot listen to right-click simply using map.on('contextmenu') and need to add the listener to
             // the map container instead
             // https://github.com/openlayers/openlayers/issues/12512#issuecomment-879403189
             map.getTargetElement().addEventListener('contextmenu', openContextMenu)
-            map.getTargetElement().addEventListener('touchstart', e => longTouchHandler.onTouchStart(e))
-            map.getTargetElement().addEventListener('touchmove', () => longTouchHandler.onTouchEnd())
-            map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
+
+            map.getTargetElement().addEventListener('touchstart', e => touchHandler.onTouchStart(e))
+            map.getTargetElement().addEventListener('touchmove', e => touchHandler.onTouchMove(e))
+            map.getTargetElement().addEventListener('touchend', e => touchHandler.onTouchEnd(e))
 
             map.on('click', () => {
                 if (menuCoordinate) {
@@ -76,26 +89,44 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
 }
 
 // See #229
-class LongTouchHandler {
-    private readonly callback: (e: any) => void
-    private currentTimeout: number = 0
-    currentEvent?: any
+class TouchHandler {
+    private readonly onTap: () => void
+    private readonly onDrag: () => void
+    private readonly onLongTouch: (e: any) => void
 
-    constructor(onLongTouch: (e: any) => void) {
-        this.callback = onLongTouch
+    private currentTimeout: number = 0
+    private currentEvent?: any
+    private pageX: number
+    private pageY: number
+    private moved: boolean
+
+    constructor(onTap: () => void, onDrag: () => void, onLongTouch: (e: any) => void) {
+        this.onTap = onTap
+        this.onDrag = onDrag
+        this.onLongTouch = onLongTouch
     }
 
     onTouchStart(e: any) {
         this.currentEvent = e
         this.currentTimeout = window.setTimeout(() => {
-            console.log('long touch')
-            if (this.currentEvent) this.callback(this.currentEvent)
+            if (this.currentEvent) this.onLongTouch(this.currentEvent)
         }, 500)
+        this.pageX = e.pageX
+        this.pageY = e.pageY
+        this.moved = false
     }
 
-    onTouchEnd() {
-        console.log('touch end')
+    onTouchMove(e: any) {
+        if (Math.abs(e.pageX - this.pageX) > 5 || Math.abs(e.pageY - this.pageY) > 5) {
+            this.moved = true
+            window.clearTimeout(this.currentTimeout)
+        }
+    }
+
+    onTouchEnd(e: any) {
         window.clearTimeout(this.currentTimeout)
+        if (this.moved) this.onDrag()
+        else this.onTap()
         this.currentEvent = undefined
     }
 }

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -57,7 +57,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchend', e => touchHandler.onTouchEnd(e))
 
             map.on('click', () => {
-                if (overlay?.getPosition()) {
+                if (overlay?.getPosition() && !touchHandler.ongoing) {
                     overlay?.setPosition(undefined)
                     setMenuCoordinate(null)
                 }
@@ -108,7 +108,7 @@ class TouchHandler {
 
     private touchStartEvent?: any
     private currentTimeout: number = 0
-    private ongoing: boolean = false
+    ongoing: boolean = false
 
     constructor(onTap: () => void, onLongTouch: (e: any) => void) {
         this.onTap = onTap

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -37,8 +37,8 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
         const touchHandler = new TouchHandler(
             // on tap
             () => {
-                overlay?.setPosition(undefined)
-                setMenuCoordinate(null)
+                // overlay?.setPosition(undefined)
+                // setMenuCoordinate(null)
             },
             // on drag
             () => {},
@@ -59,7 +59,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchend', e => touchHandler.onTouchEnd(e))
 
             map.on('click', () => {
-                if (menuCoordinate) {
+                if (overlay?.getPosition()) {
                     overlay?.setPosition(undefined)
                     setMenuCoordinate(null)
                 }
@@ -71,6 +71,21 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.removeOverlay(overlay)
         }
     }, [map])
+
+    // const closeContextMenu = () => {
+    //     if (overlay?.getPosition()) {
+    //         overlay?.setPosition(undefined)
+    //         setMenuCoordinate(null)
+    //     }
+    // }
+    //
+    // useEffect(() => {
+    //     map.on('click', closeContextMenu)
+    //     return () => {
+    //         map.un('click', closeContextMenu)
+    //     }
+    // }, [map, overlay, menuCoordinate])
+
     return (
         <div className={styles.popup} ref={container as any}>
             {menuCoordinate && (
@@ -96,9 +111,9 @@ class TouchHandler {
 
     private currentTimeout: number = 0
     private currentEvent?: any
-    private pageX: number
-    private pageY: number
-    private moved: boolean
+    private pageX: number = 0
+    private pageY: number = 0
+    private moved: boolean = false
 
     constructor(onTap: () => void, onDrag: () => void, onLongTouch: (e: any) => void) {
         this.onTap = onTap
@@ -107,10 +122,10 @@ class TouchHandler {
     }
 
     onTouchStart(e: any) {
-        this.currentEvent = e
         this.currentTimeout = window.setTimeout(() => {
             if (this.currentEvent) this.onLongTouch(this.currentEvent)
         }, 500)
+        this.currentEvent = e
         this.pageX = e.pageX
         this.pageY = e.pageY
         this.moved = false

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -45,9 +45,8 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchmove', () => longTouchHandler.onTouchEnd())
             map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
 
-            map.on('click', () => {
+            map.getTargetElement().addEventListener('click', () => {
                 overlay?.setPosition(undefined)
-                // setMenuCoordinate(null)
             })
         })
 

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -45,7 +45,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchmove', () => longTouchHandler.onTouchEnd())
             map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
 
-            map.on('click', () => {
+            map.getTargetElement().addEventListener('click', () => {
                 overlay?.setPosition(undefined)
                 setMenuCoordinate(null)
             })

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -56,12 +56,12 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchmove', e => touchHandler.onTouchMove(e))
             map.getTargetElement().addEventListener('touchend', e => touchHandler.onTouchEnd(e))
 
-            map.on('click', () => {
-                if (overlay?.getPosition() && !touchHandler.ongoing) {
-                    overlay?.setPosition(undefined)
-                    setMenuCoordinate(null)
-                }
-            })
+            // map.on('click', () => {
+            //     if (overlay?.getPosition() && !touchHandler.ongoing) {
+            //         overlay?.setPosition(undefined)
+            //         setMenuCoordinate(null)
+            //     }
+            // })
         })
 
         return () => {

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -34,29 +34,16 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             overlay.setPosition(coordinate)
         }
 
-        const touchHandler = new TouchHandler(
-            // on tap
-            () => {
-                // overlay?.setPosition(undefined)
-                // setMenuCoordinate(null)
-            },
-            // on drag
-            () => {},
-            // on long press
-            e => {
-                openContextMenu(e)
-            }
-        )
+        const longTouchHandler = new LongTouchHandler(e => openContextMenu(e))
 
         map.once('change:target', () => {
             // we cannot listen to right-click simply using map.on('contextmenu') and need to add the listener to
             // the map container instead
             // https://github.com/openlayers/openlayers/issues/12512#issuecomment-879403189
             map.getTargetElement().addEventListener('contextmenu', openContextMenu)
-
-            map.getTargetElement().addEventListener('touchstart', e => touchHandler.onTouchStart(e))
-            map.getTargetElement().addEventListener('touchmove', e => touchHandler.onTouchMove(e))
-            map.getTargetElement().addEventListener('touchend', e => touchHandler.onTouchEnd(e))
+            map.getTargetElement().addEventListener('touchstart', e => longTouchHandler.onTouchStart(e))
+            map.getTargetElement().addEventListener('touchmove', () => longTouchHandler.onTouchEnd())
+            map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
 
             map.on('click', () => {
                 if (overlay?.getPosition()) {
@@ -104,44 +91,26 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
 }
 
 // See #229
-class TouchHandler {
-    private readonly onTap: () => void
-    private readonly onDrag: () => void
-    private readonly onLongTouch: (e: any) => void
-
+class LongTouchHandler {
+    private readonly callback: (e: any) => void
     private currentTimeout: number = 0
     private currentEvent?: any
-    private pageX: number = 0
-    private pageY: number = 0
-    private moved: boolean = false
 
-    constructor(onTap: () => void, onDrag: () => void, onLongTouch: (e: any) => void) {
-        this.onTap = onTap
-        this.onDrag = onDrag
-        this.onLongTouch = onLongTouch
+    constructor(onLongTouch: (e: any) => void) {
+        this.callback = onLongTouch
     }
 
     onTouchStart(e: any) {
-        this.currentTimeout = window.setTimeout(() => {
-            if (this.currentEvent) this.onLongTouch(this.currentEvent)
-        }, 500)
         this.currentEvent = e
-        this.pageX = e.pageX
-        this.pageY = e.pageY
-        this.moved = false
+        this.currentTimeout = window.setTimeout(() => {
+            console.log('long touch')
+            if (this.currentEvent) this.callback(this.currentEvent)
+        }, 500)
     }
 
-    onTouchMove(e: any) {
-        if (Math.abs(e.pageX - this.pageX) > 5 || Math.abs(e.pageY - this.pageY) > 5) {
-            this.moved = true
-            window.clearTimeout(this.currentTimeout)
-        }
-    }
-
-    onTouchEnd(e: any) {
+    onTouchEnd() {
+        console.log('touch end')
         window.clearTimeout(this.currentTimeout)
-        if (this.moved) this.onDrag()
-        else this.onTap()
         this.currentEvent = undefined
     }
 }

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -47,7 +47,7 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
 
             map.getTargetElement().addEventListener('click', () => {
                 overlay?.setPosition(undefined)
-                setMenuCoordinate(null)
+                // setMenuCoordinate(null)
             })
         })
 

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -44,6 +44,11 @@ export default function ContextMenu({ map, route, queryPoints }: ContextMenuProp
             map.getTargetElement().addEventListener('touchstart', e => longTouchHandler.onTouchStart(e))
             map.getTargetElement().addEventListener('touchmove', () => longTouchHandler.onTouchEnd())
             map.getTargetElement().addEventListener('touchend', () => longTouchHandler.onTouchEnd())
+
+            map.on('click', () => {
+                overlay?.setPosition(undefined)
+                setMenuCoordinate(null)
+            })
         })
 
         return () => {

--- a/src/map/Popup.tsx
+++ b/src/map/Popup.tsx
@@ -70,17 +70,8 @@ export function PopupComponent({
         }
     }
 
-    // This is a workaround to make sure that clicks on the popup menu entries are not handled by the underlying map.
-    // Without this a click on the menu entries would e.g. close the menu without triggering the selected action.
-    // https://github.com/openlayers/openlayers/issues/6948#issuecomment-374915823
-    const convertToClick = (e: any) => {
-        const evt = new MouseEvent('click', { bubbles: true })
-        evt.stopPropagation = () => {}
-        e.target.dispatchEvent(evt)
-    }
-
     return (
-        <div className={styles.wrapper} onMouseUp={convertToClick}>
+        <div className={styles.wrapper}>
             <button
                 className={styles.closeBtn}
                 onClick={() => {

--- a/src/map/Popup.tsx
+++ b/src/map/Popup.tsx
@@ -70,8 +70,17 @@ export function PopupComponent({
         }
     }
 
+    // This is a workaround to make sure that clicks on the popup menu entries are not handled by the underlying map.
+    // Without this a click on the menu entries would e.g. close the menu without triggering the selected action.
+    // https://github.com/openlayers/openlayers/issues/6948#issuecomment-374915823
+    const convertToClick = (e: any) => {
+        const evt = new MouseEvent('click', { bubbles: true })
+        evt.stopPropagation = () => {}
+        e.target.dispatchEvent(evt)
+    }
+
     return (
-        <div className={styles.wrapper}>
+        <div className={styles.wrapper} onMouseUp={convertToClick}>
             <button
                 className={styles.closeBtn}
                 onClick={() => {


### PR DESCRIPTION
Fixes #135.

Apparently all we need to do is add a click handler to the map, but for some reason we cannot call `setMenuCoordinate(null)` as @karussell figured out in #232.

When I tried to fix the issue here it never worked as expected:

* After I added the click handler via `map.getTargetElement().addEventListener('click', ...` the menu closed when clicking the map, but it also just closed when I clicked on one of the menu entries (without any further action)
* I was then able to fix this with this workaround in Popup.tsx in 43d28bc0532831d3d1546f572b193f19204d9621
* ... but on iOS the menu would always close when I let go the long press, unless I was long-pressing and dragging
* When I tried `map.on('click'...)` instead it worked in the browser even without the change in Popup.tsx, but I had the same dragging issue on iOS again.
* What does seem to fix it is not calling `setMenuCoordinate(null)`, but why?

