### PR TITLE
Use new react-jsx transform

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import PathDetails from '@/pathDetails/PathDetails'
 import styles from './App.module.css'
 import {

--- a/src/PlainButton.tsx
+++ b/src/PlainButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes } from 'react'
 import styles from './PlainButton.module.css'
 
 export default function (props: ButtonHTMLAttributes<HTMLButtonElement>) {

--- a/src/layers/ContextMenu.tsx
+++ b/src/layers/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import { Map, Overlay } from 'ol'
 import { ContextMenuContent } from '@/map/ContextMenuContent'
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Coordinate, QueryPoint } from '@/stores/QueryStore'
 import { fromLonLat, toLonLat } from 'ol/proj'
 import styles from '@/layers/ContextMenu.module.css'

--- a/src/layers/MapFeaturePopup.tsx
+++ b/src/layers/MapFeaturePopup.tsx
@@ -1,5 +1,5 @@
 import { Map, Overlay } from 'ol'
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import styles from '@/layers/MapFeaturePopup.module.css'
 import { fromLonLat } from 'ol/proj'
 import { Coordinate } from '@/stores/QueryStore'

--- a/src/layers/PathDetailPopup.tsx
+++ b/src/layers/PathDetailPopup.tsx
@@ -1,5 +1,5 @@
 import { Map, Overlay } from 'ol'
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import styles from '@/layers/PathDetailPopup.module.css'
 import { PathDetailsStoreState } from '@/stores/PathDetailsStore'
 import { fromLonLat } from 'ol/proj'

--- a/src/layers/UsePathDetailsLayer.tsx
+++ b/src/layers/UsePathDetailsLayer.tsx
@@ -1,5 +1,5 @@
 import { Map } from 'ol'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import { PathDetailsStoreState } from '@/stores/PathDetailsStore'
 import { Coordinate } from '@/stores/QueryStore'
 import { FeatureCollection } from 'geojson'

--- a/src/layers/UsePathsLayer.tsx
+++ b/src/layers/UsePathsLayer.tsx
@@ -1,7 +1,7 @@
 import { Map } from 'ol'
 import { Path } from '@/api/graphhopper'
 import { FeatureCollection } from 'geojson'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { GeoJSON } from 'ol/format'

--- a/src/layers/UseQueryPointsLayer.tsx
+++ b/src/layers/UseQueryPointsLayer.tsx
@@ -1,6 +1,6 @@
 import { Feature, Map } from 'ol'
 import { QueryPoint, QueryPointType } from '@/stores/QueryStore'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
 import { Point } from 'ol/geom'

--- a/src/layers/UseRoutingGraphLayer.tsx
+++ b/src/layers/UseRoutingGraphLayer.tsx
@@ -1,5 +1,5 @@
 import { Feature, Map } from 'ol'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import VectorTileSource from 'ol/source/VectorTile'
 import VectorTileLayer from 'ol/layer/VectorTile'
 import { MVT } from 'ol/format'

--- a/src/layers/UseUrbanDensityLayer.tsx
+++ b/src/layers/UseUrbanDensityLayer.tsx
@@ -1,5 +1,5 @@
 import { Feature, Map } from 'ol'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import VectorTileSource from 'ol/source/VectorTile'
 import VectorTileLayer from 'ol/layer/VectorTile'
 import { MVT } from 'ol/format'

--- a/src/map/MapComponent.tsx
+++ b/src/map/MapComponent.tsx
@@ -1,6 +1,6 @@
 import 'ol/ol.css'
 import styles from '@/map/Map.module.css'
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { Map } from 'ol'
 
 type MapComponentProps = {

--- a/src/map/MapOptions.tsx
+++ b/src/map/MapOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import styles from './MapOptions.modules.css'
 import { MapOptionsStoreState, StyleOption } from '@/stores/MapOptionsStore'
 import Dispatcher from '@/stores/Dispatcher'

--- a/src/pathDetails/PathDetails.tsx
+++ b/src/pathDetails/PathDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import styles from '@/pathDetails/PathDetails.module.css'
 import { HeightGraph } from 'heightgraph/src/heightgraph'
 import 'heightgraph/src/heightgraph.css'

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -4,7 +4,7 @@ import 'codemirror/addon/lint/lint.css'
 // todo: this belongs to this app and we should not take it from the demo...
 import 'custom-model-editor/demo/style.css'
 import styles from '@/sidebar/CustomModelBox.module.css'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { create } from 'custom-model-editor/src/index'
 import Dispatcher from '@/stores/Dispatcher'
 import { DismissLastError, SetCustomModel } from '@/actions/Actions'

--- a/src/sidebar/MobileSidebar.tsx
+++ b/src/sidebar/MobileSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { QueryPoint, QueryPointType, QueryStoreState } from '@/stores/QueryStore'
 import { RouteStoreState } from '@/stores/RouteStore'
 import { ApiInfo, RoutingProfile } from '@/api/graphhopper'

--- a/src/sidebar/RoutingResults.tsx
+++ b/src/sidebar/RoutingResults.tsx
@@ -1,7 +1,7 @@
 import { Instruction, Path } from '@/api/graphhopper'
 import { CurrentRequest, RequestState, SubRequest } from '@/stores/QueryStore'
 import styles from './RoutingResult.module.css'
-import React, { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import Dispatcher from '@/stores/Dispatcher'
 import { SetSelectedPath } from '@/actions/Actions'
 import { metersToText, milliSecondsToText } from '@/Converters'

--- a/src/sidebar/instructions/Instructions.tsx
+++ b/src/sidebar/instructions/Instructions.tsx
@@ -1,5 +1,5 @@
 import styles from '@/sidebar/instructions/Instructions.module.css'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import uTurn from './u_turn.png'
 import uTurnLeft from './u_turn_left.png'

--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { Coordinate, QueryPoint, QueryPointType } from '@/stores/QueryStore'
 import { GeocodingHit } from '@/api/graphhopper'
 import { ErrorAction } from '@/actions/Actions'

--- a/src/sidebar/search/AddressInputAutocomplete.tsx
+++ b/src/sidebar/search/AddressInputAutocomplete.tsx
@@ -1,5 +1,5 @@
 import styles from './AddressInputAutocomplete.module.css'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import CurrentLocationIcon from './current-location.svg'
 import { tr } from '@/translation/Translation'
 

--- a/src/sidebar/search/Search.tsx
+++ b/src/sidebar/search/Search.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import Dispatcher from '@/stores/Dispatcher'
 import styles from '@/sidebar/search/Search.module.css'
 import { QueryPoint } from '@/stores/QueryStore'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "outDir": "./dist/",
         "sourceMap": true,
         "noImplicitAny": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
         "allowSyntheticDefaultImports": true,
         "baseUrl": ".",
         "importHelpers": true,


### PR DESCRIPTION
Apparently setting `"jsx": "react-jsx"` instead of `"jsx": "react"` in tsconfig.json is now the way to go: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#whats-different-in-the-new-transform

For us it means we no longer need to explicitly `import React` in `.tsx` files, which was a bit annoying because for example IntelliJ did not detect this as error and we only noticed when running the app, for example we got:

```
[tsl] ERROR in /home/me/code/routing/graphhopper/gh-maps-react/src/sidebar/search/AddressInputAutocomplete.tsx(132,10)
      TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
```