### PR TITLE
Make typescript compiler use ES2015 instead of CommonJS modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,23 +7,18 @@
         "allowSyntheticDefaultImports": true,
         "baseUrl": ".",
         "importHelpers": true,
-        "module": "CommonJS",
+        "module": "ES2015",
         "moduleResolution": "node",
         "noImplicitReturns": true,
         "strict": true,
         "target": "ES2019",
         "paths": {
             "@/*": ["src/*"],
-            "ol-mapbox-style": ["node_modules/ol-mapbox-style/src"],
-            "ol-mapbox-style/*": ["node_modules/ol-mapbox-style/src/*"]
         },
         "lib": ["ES2019", "dom", "dom.iterable"],
         "esModuleInterop": true,
         "resolveJsonModule": true,
         "skipLibCheck": true
     },
-    "include": ["./src/**/*", "./test/**/*", "node_modules/ol-mapbox-style/**/*"],
-    "typeAcquisition": {
-        "exclude": ["ol-mapbox-style"]
-    }
+    "include": ["./src/**/*", "./test/**/*"],
 }


### PR DESCRIPTION
I could be wrong, but there really isn't a good reason to set `"module": "CommonJS"` in `tsconfig.json` (anymore?). This setting defines which module system shall be used for the javascript files created by the typescript compiler. CommonJS is the default module system (the default way how to import code from one to the other) in the **node** environment. For browsers es6 modules are common nowadays. And maybe that doesn't even matter, because we have webpack which bundles all the code into a **single** file anyway (ok except the `config.js` file which is separated).

I figured that if I set `"module": "ES2015"` (or newer ES versions) there is no longer a problem with the newer `ol-mapbox-style` version which is required to upgrade to OpenLayers 7 (#204) so for that alone I think we should switch to "ES2015" ("ES2020", "ES2022", "ESNext" would also be possible, but I tried to stay conservative (no idea tbh)).