### PR TITLE
Maps deployment: fail on dispatch error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          curl -H "Authorization: token ${{ secrets.PRIVATE_GITHUB_ACCESS_TOKEN }}" \
+          curl --fail -H "Authorization: token ${{ secrets.PRIVATE_GITHUB_ACCESS_TOKEN }}" \
             -H 'Accept: application/vnd.github.everest-preview+json' \
             "https://api.github.com/repos/${{ secrets.DEPLOY_REPO }}/dispatches" \
             -d '{"event_type": "deploy-maps", "client_payload": {"branch": "${{ github.ref_name }}", "commit": "${{ github.sha }}"}}'


### PR DESCRIPTION
Right now the deployments are not being dispatched to another repo because the `curl` request fails, but the exit code of it is still 0. This PR changes this and will report an error and fail the build.