### PR TITLE
change sidebar width onMouseDown callback

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -4,7 +4,7 @@
     padding: 0;
     margin: 0;
     display: grid;
-    /* overwritten via code to achieve width change: grid-template-columns: 26rem 1fr auto; */
+    /* overwritten in App.tsx: grid-template-columns: 26rem 1fr auto; */
     grid-template-rows: 100%;
     justify-content: space-between;
     overflow: auto;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,7 @@ export default function App() {
     useQueryPointsLayer(map, query.queryPoints)
     usePathDetailsLayer(map, pathDetails)
 
-    const minSidebarWidth = 26 * 16 /*26rem*/
+    const minSidebarWidth = 26 * 18
     const [sidebarWidth, setSidebarWidth] = useState(minSidebarWidth)
 
     const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -116,7 +116,7 @@ export default function App() {
 
             const handleMouseMove = (event: MouseEvent) => {
                 const delta = event.clientX - initialX
-                if (initialWidth + delta > minSidebarWidth) setSidebarWidth(initialWidth + delta)
+                if (initialWidth + delta > minSidebarWidth * 0.8) setSidebarWidth(initialWidth + delta)
             }
 
             const handleMouseUp = () => {


### PR DESCRIPTION
Changing the width of a text field is usually easy using some CSS like

```
.CodeMirror {
    resize: both;
    overflow: auto !important;
}
```

But the editor is embedded in components that makes this impossible (it seems -> [no](https://github.com/graphhopper/graphhopper-maps/pull/333)).

Usually websites offer simple buttons to maximize and minimize the component but this is very limiting and the button for this is IMO convoluted for this small feature.

One better solution I found (that is not too involved): resize of the width using a onMouseDown callback, so similar how resizing a window usually works. Limit the callback so that dragging is possible only on the very right of the sidebar. Users would not notice this feature and so we *independently* highlight a newly added (thin) component on hover for this area.

You can try it [here](https://graphhopper.com/maps-dev/change_sidebar_width).

 TODO:

 - [ ] on mobile the layout is broken
 - [ ] map.fitBounds happens independent of this size. Not sure if this is a bug or can be seen as intended. Same if it overlaps the elevation widget.

![grafik](https://user-images.githubusercontent.com/129644/231850326-f2726b86-00c8-465a-acba-c700b75f36a4.png)
