### PR TITLE
Add external MVT layer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import Menu from '@/sidebar/menu.svg'
 import Cross from '@/sidebar/times-solid.svg'
 import PlainButton from '@/PlainButton'
 import useAreasLayer from '@/layers/UseAreasLayer'
+import useExternalMVTLayer from '@/layers/UseExternalMVTLayer'
 
 export const POPUP_CONTAINER_ID = 'popup-container'
 export const SIDEBAR_CONTENT_ID = 'sidebar-content'
@@ -98,6 +99,7 @@ export default function App() {
 
     // our different map layers
     useBackgroundLayer(map, mapOptions.selectedStyle)
+    useExternalMVTLayer(map, mapOptions.externalMVTEnabled)
     useMapBorderLayer(map, info.bbox)
     useAreasLayer(map, settings.drawAreasEnabled, query.customModelStr, query.customModelEnabled)
     useRoutingGraphLayer(map, mapOptions.routingGraphEnabled)

--- a/src/actions/Actions.ts
+++ b/src/actions/Actions.ts
@@ -166,6 +166,14 @@ export class ToggleUrbanDensityLayer implements Action {
     }
 }
 
+export class ToggleExternalMVTLayer implements Action {
+    readonly externalMVTLayerEnabled: boolean
+
+    constructor(externalMVTLayerEnabled: boolean) {
+        this.externalMVTLayerEnabled = externalMVTLayerEnabled
+    }
+}
+
 export class MapIsLoaded implements Action {}
 
 export class ZoomMapToPoint implements Action {

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -20,6 +20,17 @@ declare module 'config' {
         snapPreventions: string[]
     }
     const routingGraphLayerAllowed: boolean
+    const externalMVTLayer: {
+        url: string
+        styles: {
+            // Maps mvt layer names to style properties. Only the layers listed here will be visible.
+            [key: string]: {
+                color: string
+                width: number
+            }
+        }
+        maxZoom?: number
+    }
     const profiles: object
 }
 

--- a/src/layers/UseExternalMVTLayer.tsx
+++ b/src/layers/UseExternalMVTLayer.tsx
@@ -1,0 +1,104 @@
+import { Feature, Map, MapBrowserEvent } from 'ol'
+import { useEffect } from 'react'
+import VectorTileSource from 'ol/source/VectorTile'
+import VectorTileLayer from 'ol/layer/VectorTile'
+import { MVT } from 'ol/format'
+import { Stroke, Style } from 'ol/style'
+import { toLonLat } from 'ol/proj'
+import { RoutingGraphHover } from '@/actions/Actions'
+import Dispatcher from '@/stores/Dispatcher'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import * as config from 'config'
+
+export default function useExternalMVTLayer(map: Map, externalMVTLayerEnabled: boolean) {
+    useEffect(() => {
+        const externalMVTLayer = new VectorTileLayer({
+            declutter: true,
+            source: new VectorTileSource({
+                attributions: '',
+                format: new MVT({
+                    // without this we won't be able to simply add the features to the selectionSource below, see: https://gis.stackexchange.com/a/407634
+                    featureClass: Feature,
+                }),
+                url: config.externalMVTLayer ? config.externalMVTLayer.url : '',
+                maxZoom: config.externalMVTLayer ? config.externalMVTLayer.maxZoom : 14,
+            }),
+            renderMode: 'vector',
+            // make sure this layer is on top of the background layer
+            zIndex: 0.6,
+            style: ((feature: Feature) => getStyle(feature)) as any,
+        })
+
+        // We use a separate VectorLayer (not VectorTileLayer) to highlight the hovered feature. We need this because
+        // the vector tile source often only supports a maximum zoom level of, e.g. 14 or 15, and when we zoom beyond this
+        // updating the style (needed to highlight the feature) no longer works.
+        const selectionSource = new VectorSource()
+        const selectionLayer = new VectorLayer({
+            source: selectionSource,
+            zIndex: 0.7,
+            style: feature => {
+                const style = config.externalMVTLayer.styles[feature.get('layer')]
+                return new Style({
+                    stroke: new Stroke({
+                        color: brighten(style.color, 20),
+                        width: style.width * 1.1,
+                    }),
+                })
+            },
+        })
+
+        const onHover = (e: MapBrowserEvent<UIEvent>) => {
+            selectionSource.clear()
+            const features = map.getFeaturesAtPixel(e.pixel, {
+                layerFilter: l => l === externalMVTLayer,
+                hitTolerance: 5,
+            })
+            if (features.length > 0) {
+                selectionSource.addFeatures(features as any)
+                const lonLat = toLonLat(e.coordinate)
+                // we only display the properties of the first feature
+                const properties = features[0].getProperties()
+                Dispatcher.dispatch(new RoutingGraphHover({ lat: lonLat[1], lng: lonLat[0] }, properties))
+            } else {
+                Dispatcher.dispatch(new RoutingGraphHover(null, {}))
+            }
+        }
+
+        map.removeLayer(externalMVTLayer)
+        map.removeLayer(selectionLayer)
+        if (externalMVTLayerEnabled) {
+            map.addLayer(externalMVTLayer)
+            map.addLayer(selectionLayer)
+            map.on('pointermove', onHover)
+        }
+        return () => {
+            map.un('pointermove', onHover)
+            map.removeLayer(externalMVTLayer)
+            map.removeLayer(selectionLayer)
+        }
+    }, [map, externalMVTLayerEnabled])
+}
+
+function getStyle(feature: Feature): Style | undefined {
+    const style = config.externalMVTLayer.styles[feature.get('layer')]
+    if (style)
+        return new Style({
+            stroke: new Stroke({
+                color: style.color,
+                width: style.width,
+            }),
+        })
+    // do not render this feature
+    else return undefined
+}
+
+function brighten(hexColor: string, amount: number) {
+    const red = parseInt(hexColor.slice(1, 3), 16)
+    const green = parseInt(hexColor.slice(3, 5), 16)
+    const blue = parseInt(hexColor.slice(5, 7), 16)
+    const newRed = Math.min(255, red + amount)
+    const newGreen = Math.min(255, green + amount)
+    const newBlue = Math.min(255, blue + amount)
+    return `#${newRed.toString(16)}${newGreen.toString(16)}${newBlue.toString(16)}`
+}

--- a/src/layers/UseExternalMVTLayer.tsx
+++ b/src/layers/UseExternalMVTLayer.tsx
@@ -24,6 +24,7 @@ export default function useExternalMVTLayer(map: Map, externalMVTLayerEnabled: b
                 url: config.externalMVTLayer ? config.externalMVTLayer.url : '',
                 maxZoom: config.externalMVTLayer ? config.externalMVTLayer.maxZoom : 14,
             }),
+            // without this the features become very blurry when we zoom beyond the maximum zoom level of the mvt source
             renderMode: 'vector',
             // make sure this layer is on top of the background layer
             zIndex: 0.6,

--- a/src/map/MapOptions.tsx
+++ b/src/map/MapOptions.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import styles from './MapOptions.module.css'
 import { MapOptionsStoreState } from '@/stores/MapOptionsStore'
 import Dispatcher from '@/stores/Dispatcher'
-import { SelectMapLayer, ToggleRoutingGraph, ToggleUrbanDensityLayer } from '@/actions/Actions'
+import { SelectMapLayer, ToggleExternalMVTLayer, ToggleRoutingGraph, ToggleUrbanDensityLayer } from '@/actions/Actions'
 import PlainButton from '@/PlainButton'
 import LayerImg from './layer-group-solid.svg'
 import * as config from 'config'
@@ -81,6 +81,22 @@ const Options = function ({ storeState, notifyChanged }: OptionsProps) {
                             }}
                         />
                         <label htmlFor="urban-density-checkbox">Show Urban Density</label>
+                    </div>
+                </>
+            )}
+            {config.externalMVTLayer && (
+                <>
+                    <div className={styles.option}>
+                        <input
+                            type="checkbox"
+                            id="external-mvt-layer-checkbox"
+                            checked={storeState.externalMVTEnabled}
+                            onChange={e => {
+                                notifyChanged()
+                                Dispatcher.dispatch(new ToggleExternalMVTLayer(e.target.checked))
+                            }}
+                        />
+                        <label htmlFor="external-mvt-layer-checkbox">Show External MVT</label>
                     </div>
                 </>
             )}

--- a/src/sidebar/CustomModelBox.tsx
+++ b/src/sidebar/CustomModelBox.tsx
@@ -97,7 +97,12 @@ export default function CustomModelBox({
                 </PlainButton>
                 <div style={{ color: customModelEnabled ? '#5b616a' : 'gray' }}>{tr('custom_model_enabled')}</div>
                 {customModelEnabled && (
-                    <PlainButton className={styles.drawAreas} title={tr('draw_areas_enabled')} style={{ color: drawAreas ? '' : 'lightgray' }} onClick={() => Dispatcher.dispatch(new DrawAreas(!drawAreas))}>
+                    <PlainButton
+                        className={styles.drawAreas}
+                        title={tr('draw_areas_enabled')}
+                        style={{ color: drawAreas ? '' : 'lightgray' }}
+                        onClick={() => Dispatcher.dispatch(new DrawAreas(!drawAreas))}
+                    >
                         {drawAreas ? <DrawAreasIcon /> : <DrawAreasDisabledIcon />}
                     </PlainButton>
                 )}

--- a/src/sidebar/RoutingResults.tsx
+++ b/src/sidebar/RoutingResults.tsx
@@ -219,10 +219,7 @@ function RoutingResult({ path, isSelected, profile }: { path: Path; isSelected: 
                             setType={t => setSelectedRH(t)}
                             type={'trunk'}
                             child={<DangerousIcon />}
-                            value={
-                                trunkInfo.distance > 0 &&
-                                metersToShortText(trunkInfo.distance, showDistanceInMiles)
-                            }
+                            value={trunkInfo.distance > 0 && metersToShortText(trunkInfo.distance, showDistanceInMiles)}
                             selected={selectedRH}
                             segments={trunkInfo.segments}
                         />

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -1,6 +1,12 @@
 import Store from '@/stores/Store'
 import { Action } from '@/stores/Dispatcher'
-import { MapIsLoaded, SelectMapLayer, ToggleRoutingGraph, ToggleUrbanDensityLayer } from '@/actions/Actions'
+import {
+    MapIsLoaded,
+    SelectMapLayer,
+    ToggleExternalMVTLayer,
+    ToggleRoutingGraph,
+    ToggleUrbanDensityLayer,
+} from '@/actions/Actions'
 import config from 'config'
 
 const osApiKey = config.keys.omniscale
@@ -17,6 +23,7 @@ export interface MapOptionsStoreState {
     isMapLoaded: boolean
     routingGraphEnabled: boolean
     urbanDensityEnabled: boolean
+    externalMVTEnabled: boolean
 }
 
 export interface StyleOption {
@@ -208,6 +215,7 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
             styleOptions,
             routingGraphEnabled: false,
             urbanDensityEnabled: false,
+            externalMVTEnabled: false,
             isMapLoaded: false,
         }
     }
@@ -229,6 +237,11 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
             return {
                 ...state,
                 urbanDensityEnabled: action.urbanDensityEnabled,
+            }
+        } else if (action instanceof ToggleExternalMVTLayer) {
+            return {
+                ...state,
+                externalMVTEnabled: action.externalMVTLayerEnabled,
             }
         } else if (action instanceof MapIsLoaded) {
             return {


### PR DESCRIPTION
Here I added an extra MVT layer that can be enabled via config(-local).js and used to display external MVT data. 
For example:
```js
// in config-local.js
 externalMVTLayer: {
        url: 'http://localhost:8080/{z}/{x}/{y}.pbf',
        styles: {
            'layer1': {
                color: 'red',
                width: 2
            },
            'layer2': {
                color: 'blue',
                width: 4
            }
        }
    },
```
will show the `layer1/2` layers of the MVT source running on `localhost:8080` when we enable the checkbox in the layers menu.
I used this to display OSM data (pedestrian areas specifically) served from the incredible https://github.com/onthegomap/planetiler project. Many thanks @msbarry!