### PR TITLE
round minutes

### DIFF
--- a/src/Converters.ts
+++ b/src/Converters.ts
@@ -4,7 +4,7 @@ import { Coordinate } from '@/stores/QueryStore'
 
 export function milliSecondsToText(seconds: number) {
     const hours = Math.floor(seconds / 3600000)
-    const minutes = Math.floor((seconds % 3600000) / 60000)
+    const minutes = Math.round((seconds % 3600000) / 60000)
 
     const hourText = hours > 0 ? hours + ' h' : ''
     if (minutes == 0 && hourText.length > 0) return hourText


### PR DESCRIPTION
This route takes 118sec, but the sidebar shows 1min since it use Math.floor() to convert ms in min. 

<img width="1376" alt="Screenshot 2023-07-15 at 10 59 51" src="https://github.com/graphhopper/graphhopper-maps/assets/5714926/41c1ed53-1c97-44bf-b751-43b147414d37">

Since we do not show seconds here, it should use round() here.