### PR TITLE
onClick isn't triggered for touch devices

### DIFF
--- a/src/sidebar/search/AddressInput.tsx
+++ b/src/sidebar/search/AddressInput.tsx
@@ -37,7 +37,6 @@ export default function AddressInput(props: AddressInputProps) {
 
     // keep track of focus and toggle fullscreen display on small screens
     const [hasFocus, setHasFocus] = useState(false)
-    const [mouseDownOnSuggestion, setMouseDownOnSuggestion] = useState(false)
     const isSmallScreen = useMediaQuery({ query: '(max-width: 44rem)' })
 
     // container for geocoding results which gets set by the geocoder class and set to empty if the underlying query point gets changed from outside
@@ -175,9 +174,8 @@ export default function AddressInput(props: AddressInputProps) {
                         props.clearDragDrop()
                     }}
                     onBlur={() => {
-                        // Suppress onBlur if there was a mouseDown event on a suggested item.
-                        // Otherwise, the item would be removed before onPointerUp handler can be called (in AutocompleteEntry)
-                        if (isSmallScreen || mouseDownOnSuggestion) return
+                        // Suppress onBlur if we are on the small screen
+                        if (isSmallScreen) return
                         setHasFocus(false)
                         hideSuggestions()
                     }}
@@ -208,7 +206,6 @@ export default function AddressInput(props: AddressInputProps) {
                         <Autocomplete
                             items={autocompleteItems}
                             highlightedItem={autocompleteItems[highlightedResult]}
-                            setMouseDown={setMouseDownOnSuggestion}
                             onSelect={item => {
                                 setHasFocus(false)
                                 if (item instanceof GeocodingItem) {

--- a/src/sidebar/search/AddressInputAutocomplete.tsx
+++ b/src/sidebar/search/AddressInputAutocomplete.tsx
@@ -38,16 +38,11 @@ export interface AutocompleteProps {
     items: AutocompleteItem[]
     highlightedItem: AutocompleteItem
     onSelect: (hit: AutocompleteItem) => void
-    setMouseDown: (b: boolean) => void
 }
 
-export default function Autocomplete({ items, highlightedItem, onSelect, setMouseDown }: AutocompleteProps) {
+export default function Autocomplete({ items, highlightedItem, onSelect }: AutocompleteProps) {
     return (
-        <ul
-            onMouseDown={() => setMouseDown(true)}
-            onMouseUp={() => setMouseDown(false)}
-            onMouseLeave={() => setMouseDown(false)}
-        >
+        <ul>
             {items.map((item, i) => (
                 <li key={i} className={styles.autocompleteItem}>
                     {mapToComponent(item, highlightedItem === item, onSelect)}
@@ -136,7 +131,20 @@ function AutocompleteEntry({
 }) {
     const className = isHighlighted ? styles.selectableItem + ' ' + styles.highlightedItem : styles.selectableItem
     return (
-        <button className={className} onPointerUp={() => onSelect()}>
+        <button
+            className={className}
+            // using click events for mouse interaction and touch end to select an entry.
+            onClick={() => onSelect()}
+            onTouchEnd={e => {
+                e.preventDefault()
+                onSelect()
+            }}
+
+            // prevent blur event for our input (seems to be only required for mouse)
+            onMouseDown={e => {
+                e.preventDefault()
+            }}
+        >
             {children}
         </button>
     )


### PR DESCRIPTION
Fixes #363. To be tested on multiple devices [here](https://graphhopper.com/maps-dev/issue_363/) ... e.g. it should not trigger a click into a different input afterwards.

The onBlur-pointerDownOnSuggestion workaround is only necessary for onClick but not if we use onMouseDown And the onClick of AutocompleteEntry somehow isn't triggered for touch devices although it should - maybe the onBlur event is the problem here too. Regardless of this: if we use `onTouchStart={()=>onSelect()}` (or onTouchEnd) it seems works on touch devices too. i.e. we can fix the issue and remove the onBlur-pointerDownOnSuggestion workaround via using onPointerDown instead of onClick. 

**Update**: no. The UX is ugly when using onPointerDown as the finger is then still on the screen (or mouse is down) triggering wrong things like adding more locations (i.e. clicking elements underneath the autocomplete box). Using onPointerUp seems to avoid these problems and still provide a single working method for mouse+touch. 

**Update**: We should use [our old pointer-event-cancel method](https://github.com/graphhopper/graphhopper-maps/blob/afde87c1ceb34a9d35da767b294db55dc89ca7de/src/sidebar/search/AddressInputAutocomplete.tsx#L135-L155) as it is less code. Somehow the "touch cancellation" does not work -> remove that for now (even less code).