### PR TITLE
Wrap Overflowing Entries in Profile Selector

### DIFF
--- a/src/sidebar/search/routingProfiles/RoutingProfiles.module.css
+++ b/src/sidebar/search/routingProfiles/RoutingProfiles.module.css
@@ -8,6 +8,7 @@
     width: 100%;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     justify-content: center;
     padding-right: 0.5em;
 }


### PR DESCRIPTION
If there are a lot of profiles configured and there is not enough space to show all them in the side bar the rendering breaks:
![image](https://github.com/graphhopper/graphhopper-maps/assets/12509703/97129a3b-cd64-4b04-84f3-4dbb4c24a045)

This change would wrap overflowing entries of the list into a new line while still maintaining other style properties:
![image](https://github.com/graphhopper/graphhopper-maps/assets/12509703/cfa441b9-36e2-4e87-a95c-959146226766)
