### PR TITLE
Sort the map features in popup

### DIFF
--- a/src/layers/MapFeaturePopup.tsx
+++ b/src/layers/MapFeaturePopup.tsx
@@ -18,7 +18,7 @@ export default function MapFeaturePopup({ map, properties, coordinate }: MapFeat
         <MapPopup map={map} coordinate={coordinate}>
             <div className={styles.popup}>
                 <ul>
-                    {Object.entries(properties).map(([k, v], index) => {
+                    {Object.entries(properties).sort().map(([k, v], index) => {
                         return <li key={index}>{`${k}=${v}`}</li>
                     })}
                 </ul>


### PR DESCRIPTION
When you have a long list of encoded values the map feature popup is difficult to inspect. This PR sorts the list:
![Bildschirmfoto vom 2024-06-28 15-27-33](https://github.com/graphhopper/graphhopper-maps/assets/6134544/a391ee78-5ff5-44bc-8dd3-5585eed38190)
