### PR TITLE
Hide paths while pressing the "h" key or press a small icon

### DIFF
--- a/src/layers/UsePathsLayer.tsx
+++ b/src/layers/UsePathsLayer.tsx
@@ -24,16 +24,18 @@ export default function usePathsLayer(map: Map, paths: Path[], selectedPath: Pat
     const [showPaths, setShowPaths] = useState(true)
     useEffect(() => {
         removeCurrentPathLayers(map)
-        addUnselectedPathsLayer(
-            map,
-            paths.filter(p => p != selectedPath)
-        )
-        addSelectedPathsLayer(map, selectedPath)
-        addAccessNetworkLayer(map, selectedPath, queryPoints)
+        if (showPaths) {
+            addUnselectedPathsLayer(
+                map,
+                paths.filter(p => p != selectedPath)
+            )
+            addSelectedPathsLayer(map, selectedPath)
+            addAccessNetworkLayer(map, selectedPath, queryPoints)
+        }
         return () => {
             removeCurrentPathLayers(map)
         }
-    }, [map, paths, selectedPath])
+    }, [map, paths, selectedPath, showPaths])
     useEffect(() => {
       const handleKeyDown = (e: KeyboardEvent) => {
           if (e.key === 'h') setShowPaths(false)
@@ -48,17 +50,6 @@ export default function usePathsLayer(map: Map, paths: Path[], selectedPath: Pat
           window.removeEventListener('keyup', handleKeyUp)
       }
     } , [])
-    useEffect(() => {
-        removeCurrentPathLayers(map)
-        if (showPaths) {
-            addUnselectedPathsLayer(map, paths.filter(p => p != selectedPath))
-            addSelectedPathsLayer(map, selectedPath)
-            addAccessNetworkLayer(map, selectedPath, queryPoints)
-        }
-        return () => {
-            removeCurrentPathLayers(map)
-        }
-    }, [map, paths, selectedPath, showPaths])
 }
 
 function removeCurrentPathLayers(map: Map) {


### PR DESCRIPTION
Implement the suggested solution for #334. While pressing the "h" key, the paths are removed such that one can see the map details of the roads. Additionally, a small button next right to the map attribution also hides or shows again the paths.

Please review and provide feedback if there is a chance that this gets merged. Currently, the translation for the button tool tip is missing as I didn't want to change the spreadsheet as I don't know if this can get merged.