### PR TITLE
DRY: Use already defined method isFoot to determine type of profile

### DIFF
--- a/src/pathDetails/elevationWidget/colors.ts
+++ b/src/pathDetails/elevationWidget/colors.ts
@@ -1,3 +1,5 @@
+import { ApiImpl } from '@/api/Api'
+
 export const SURFACE_COLORS: Record<string, string> = {
     // Paved (greens)
     asphalt: '#2E7D32',
@@ -134,7 +136,7 @@ export function getSpeedThresholds(profile: string): number[] {
         profile.includes('scooter') ||
         profile.includes('bus') ||
         profile.includes('motorcycle')
-    const isFootLike = profile.includes('hike') || profile.includes('foot')
+    const isFootLike = ApiImpl.isFootLike(profile)
 
     if (isMotorVehicle) return [30, 50, 80]
     if (isFootLike) return [3, 4, 5]


### PR DESCRIPTION
While working on a fork of this project as a new version of the [OpenRailRouting web frontend](https://routing.openrailrouting.org/), I  came across this tiny piece of duplicated code.

`ApiImpl.isFootLike` is already used elsewhere. It seems that this line was overseen some time ago.