### PR TITLE
shorter URL with flex polyline and compressed names/custom_model

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -8,3 +8,4 @@ It includes the following software and creative work:
 
  * see package.json for the direct dependencies
  * most images from [Google Fonts](https://fonts.google.com/icons) - Apache License 2.0
+ * `src/util/flexPolyline.ts` is vendored from [heremaps/flexible-polyline](https://github.com/heremaps/flexible-polyline) (Copyright 2019 HERE Europe B.V., MIT License)

--- a/src/NavBar.ts
+++ b/src/NavBar.ts
@@ -1,6 +1,15 @@
 import { coordinateToText } from '@/Converters'
 import Dispatcher from '@/stores/Dispatcher'
-import { ClearPoints, SelectMapLayer, SetBBox, SetQueryPoints, SetVehicleProfile } from '@/actions/Actions'
+import {
+    ClearPoints,
+    ErrorAction,
+    SelectMapLayer,
+    SetBBox,
+    SetCustomModel,
+    SetCustomModelEnabled,
+    SetQueryPoints,
+    SetVehicleProfile,
+} from '@/actions/Actions'
 // import the window like this so that it can be mocked during testing
 import { window } from '@/Window'
 import QueryStore, { QueryPoint, QueryPointType, QueryStoreState } from '@/stores/QueryStore'
@@ -9,6 +18,18 @@ import { ApiImpl, getApi } from '@/api/Api'
 import { AddressParseResult } from '@/pois/AddressParseResult'
 import { getQueryStore } from '@/stores/Stores'
 import { getBBoxFromCoord, getBBoxPoints } from '@/utils'
+import { decodeCoords, encodeCoords } from '@/util/flexPolyline'
+import { canCompress, deflateB64url, inflateB64url } from '@/util/urlCompress'
+
+// Minimum number of (initialized) waypoints before we switch from the legible
+// `point=lat,lng` format to the compact `fpolyline=` representation. For 1-3
+// points the URL stays human-readable; the savings only become substantial
+// once a route gets long enough to be tedious to read anyway.
+const FPOLYLINE_THRESHOLD = 4
+
+// Names delimiter inside the compressed `cnames` blob. Stripped from names on
+// encode so the split on decode is unambiguous.
+const NAMES_SEP = '*'
 
 export default class NavBar {
     private readonly queryStore: QueryStore
@@ -23,23 +44,55 @@ export default class NavBar {
 
     async startSyncingUrlWithAppState() {
         // our first history entry shall be the one that we end up with when the app loads for the first time
-        window.history.replaceState(null, '', this.createUrlFromState())
+        const url = await this.createUrlFromState()
+        window.history.replaceState(null, '', url)
         this.queryStore.register(() => this.updateUrlFromState())
         this.mapStore.register(() => this.updateUrlFromState())
     }
 
-    private static createUrl(baseUrl: string, queryStoreState: QueryStoreState, mapState: MapOptionsStoreState) {
+    private static async createUrl(
+        baseUrl: string,
+        queryStoreState: QueryStoreState,
+        mapState: MapOptionsStoreState,
+    ): Promise<URL> {
         const result = new URL(baseUrl)
-        if (queryStoreState.queryPoints.filter(point => point.isInitialized).length > 0) {
-            queryStoreState.queryPoints
-                .map(point => (!point.isInitialized ? '' : NavBar.pointToParam(point)))
-                .forEach(pointAsString => result.searchParams.append('point', pointAsString))
+        const points = queryStoreState.queryPoints
+        const allInitialized = points.length > 0 && points.every(p => p.isInitialized)
+
+        // We only use the compact `fpolyline`/`cnames`/`cmodel` format when the
+        // browser exposes CompressionStream. Older browsers fall back to the legacy
+        // `point=` + `custom_model=` representation so they keep producing usable
+        // (just longer) share URLs.
+        const compressionAvailable = canCompress()
+
+        if (compressionAvailable && allInitialized && points.length >= FPOLYLINE_THRESHOLD) {
+            result.searchParams.append('fpolyline', encodeCoords(points.map(p => p.coordinate)))
+            const names = points.map(p => {
+                const coordText = coordinateToText(p.coordinate)
+                return p.queryText === coordText ? '' : p.queryText.split(NAMES_SEP).join('')
+            })
+            if (names.some(n => n.length > 0)) {
+                result.searchParams.append('cnames', await deflateB64url(names.join(NAMES_SEP)))
+            }
+        } else if (points.some(p => p.isInitialized)) {
+            // Legacy emission for short routes, mixed-init states, and old browsers.
+            // Only emits when at least one point is set so a clean app state doesn't
+            // produce an ugly `?point=&point=` URL.
+            points
+                .map(p => (!p.isInitialized ? '' : NavBar.pointToParam(p)))
+                .forEach(s => result.searchParams.append('point', s))
         }
 
         result.searchParams.append('profile', queryStoreState.routingProfile.name)
-        result.searchParams.append('layer', mapState.selectedStyle.name)
-        if (queryStoreState.customModelEnabled)
-            result.searchParams.append('custom_model', queryStoreState.customModelStr.replace(/\s+/g, ''))
+        result.searchParams.append('l', mapState.selectedStyle.shortName)
+        if (queryStoreState.customModelEnabled) {
+            const cm = queryStoreState.customModelStr.replace(/\s+/g, '')
+            if (compressionAvailable) {
+                result.searchParams.append('cmodel', await deflateB64url(cm))
+            } else {
+                result.searchParams.append('custom_model', cm)
+            }
+        }
 
         return result
     }
@@ -49,10 +102,44 @@ export default class NavBar {
         return coordinate === point.queryText ? coordinate : coordinate + '_' + point.queryText
     }
 
-    private static parsePoints(url: URL): QueryPoint[] {
+    private static async parsePoints(url: URL): Promise<QueryPoint[]> {
+        const fpolyline = url.searchParams.get('fpolyline')
+        if (fpolyline) {
+            let coords
+            try {
+                coords = decodeCoords(fpolyline)
+            } catch {
+                // Truncated, garbled, or future-version polyline — without coords
+                // there's no route at all, so let the user know rather than showing
+                // an empty map. cnames failures stay silent (names don't affect the
+                // route — just the labels).
+                Dispatcher.dispatch(
+                    new ErrorAction(
+                        'Could not decode the waypoints from the URL. The shared link may be truncated or malformed.',
+                    ),
+                )
+                return []
+            }
+            const cnames = url.searchParams.get('cnames')
+            let names: string[] = []
+            if (cnames && canCompress()) {
+                try {
+                    names = (await inflateB64url(cnames)).split(NAMES_SEP)
+                } catch {
+                    names = []
+                }
+            }
+            return coords.map((coordinate, idx) => ({
+                coordinate,
+                isInitialized: true,
+                id: idx,
+                queryText: names[idx] && names[idx].length > 0 ? names[idx] : coordinateToText(coordinate),
+                color: '',
+                type: QueryPointType.Via,
+            }))
+        }
         return url.searchParams.getAll('point').map((parameter, idx) => {
             const split = parameter.split('_')
-
             const point = {
                 coordinate: { lat: 0, lng: 0 },
                 isInitialized: false,
@@ -74,6 +161,27 @@ export default class NavBar {
         })
     }
 
+    private static async parseCustomModel(url: URL): Promise<string | null> {
+        const compressed = url.searchParams.get('cmodel')
+        if (compressed) {
+            if (canCompress()) {
+                try {
+                    return await inflateB64url(compressed)
+                } catch {}
+            }
+            // cmodel is authoritative when present — don't silently swap in a
+            // potentially-different `custom_model=` value as a fallback.
+            Dispatcher.dispatch(
+                new ErrorAction(
+                    'Could not decode the custom routing model from the URL. ' +
+                        'The route is being shown without the custom model and will differ from the original.',
+                ),
+            )
+            return null
+        }
+        return url.searchParams.get('custom_model')
+    }
+
     private static parseCoordinate(params: string) {
         const coordinateParams = params.split(',')
         if (coordinateParams.length !== 2) throw Error('Could not parse coordinate with value: "' + params[0] + '"')
@@ -92,7 +200,7 @@ export default class NavBar {
     }
 
     private static parseLayer(url: URL): string | null {
-        return url.searchParams.get('layer')
+        return url.searchParams.get('l') ?? url.searchParams.get('layer')
     }
 
     async updateStateFromUrl() {
@@ -106,7 +214,7 @@ export default class NavBar {
         if (parsedProfileName)
             // this won't trigger a route request because we just cleared the points
             Dispatcher.dispatch(new SetVehicleProfile({ name: parsedProfileName }))
-        const parsedPoints = NavBar.parsePoints(url)
+        const parsedPoints = await NavBar.parsePoints(url)
 
         // support legacy URLs without coordinates (not initialized) and only text, see #199
         if (parsedPoints.some(p => !p.isInitialized && p.queryText.length > 0)) {
@@ -150,6 +258,12 @@ export default class NavBar {
         const parsedLayer = NavBar.parseLayer(url)
         if (parsedLayer) Dispatcher.dispatch(new SelectMapLayer(parsedLayer))
 
+        const customModelStr = await NavBar.parseCustomModel(url)
+        if (customModelStr) {
+            Dispatcher.dispatch(new SetCustomModel(customModelStr, true))
+            Dispatcher.dispatch(new SetCustomModelEnabled(true))
+        }
+
         this.ignoreStateUpdates = false
     }
 
@@ -165,17 +279,18 @@ export default class NavBar {
         return Dispatcher.dispatch(new SetQueryPoints(points))
     }
 
-    public updateUrlFromState() {
+    public async updateUrlFromState() {
         if (this.ignoreStateUpdates) return
-        const newHref = this.createUrlFromState()
+        const newHref = await this.createUrlFromState()
         if (newHref !== window.location.href) window.history.pushState(null, '', newHref)
     }
 
-    private createUrlFromState() {
-        return NavBar.createUrl(
+    private async createUrlFromState(): Promise<string> {
+        const url = await NavBar.createUrl(
             window.location.origin + window.location.pathname,
             this.queryStore.state,
             this.mapStore.state,
-        ).toString()
+        )
+        return url.toString()
     }
 }

--- a/src/NavBar.ts
+++ b/src/NavBar.ts
@@ -36,6 +36,9 @@ export default class NavBar {
     private readonly queryStore: QueryStore
     private readonly mapStore: MapOptionsStore
     private ignoreStateUpdates = false
+    // Monotonic id so an older URL build can't clobber a newer one if their
+    // async compressions finish out of order.
+    private urlChangeId = 0
 
     constructor(queryStore: QueryStore, mapStore: MapOptionsStore) {
         this.queryStore = queryStore
@@ -289,7 +292,11 @@ export default class NavBar {
 
     public async updateUrlFromState() {
         if (this.ignoreStateUpdates) return
+        const currentId = ++this.urlChangeId
         const newHref = await this.createUrlFromState()
+        // A later state change started another build while we were awaiting
+        // compression — its result is strictly newer, so drop ours.
+        if (currentId !== this.urlChangeId) return
         if (newHref !== window.location.href) window.history.pushState(null, '', newHref)
     }
 

--- a/src/NavBar.ts
+++ b/src/NavBar.ts
@@ -20,6 +20,7 @@ import { getQueryStore } from '@/stores/Stores'
 import { getBBoxFromCoord, getBBoxPoints } from '@/utils'
 import { decodeCoords, encodeCoords } from '@/util/flexPolyline'
 import { canCompress, deflateB64url, inflateB64url } from '@/util/urlCompress'
+import { customModel2prettyString } from '@/sidebar/CustomModelExamples'
 
 // Minimum number of (initialized) waypoints before we switch from the legible
 // `point=lat,lng` format to the compact `fpolyline=` representation. For 1-3
@@ -260,7 +261,13 @@ export default class NavBar {
 
         const customModelStr = await NavBar.parseCustomModel(url)
         if (customModelStr) {
-            Dispatcher.dispatch(new SetCustomModel(customModelStr, true))
+            // Pretty-print so the editor shows readable JSON (URL form is minified).
+            // Mirrors QueryStore.getInitialState behaviour for the initial-load case.
+            let prettyStr = customModelStr
+            try {
+                prettyStr = customModel2prettyString(JSON.parse(customModelStr))
+            } catch {}
+            Dispatcher.dispatch(new SetCustomModel(prettyStr, true))
             Dispatcher.dispatch(new SetCustomModelEnabled(true))
         }
 

--- a/src/stores/MapOptionsStore.ts
+++ b/src/stores/MapOptionsStore.ts
@@ -28,6 +28,9 @@ export interface MapOptionsStoreState {
 
 export interface StyleOption {
     name: string
+    // Short code used in share URLs (`l=<shortName>`). Avoids leaking the full
+    // display name and brand strings into URLs.
+    shortName: string
     type: 'raster' | 'vector'
     url: string[] | string
     attribution: string
@@ -53,12 +56,14 @@ const retina2x = isRetina ? '@2x' : ''
 
 const mapTilerSatellite: VectorStyle = {
     name: 'MapTiler Satellite',
+    shortName: 'maptlrsat',
     type: 'vector',
     url: 'https://api.maptiler.com/maps/hybrid/style.json?key=' + mapTilerKey,
     attribution: osmAttribution + ', &copy; <a href="https://www.maptiler.com/copyright/" target="_blank">MapTiler</a>',
 }
 const osmOrg: RasterStyle = {
     name: 'OpenStreetMap',
+    shortName: 'osm',
     type: 'raster',
     url: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
     attribution: osmAttribution,
@@ -66,6 +71,7 @@ const osmOrg: RasterStyle = {
 }
 const osmCycl: RasterStyle = {
     name: 'Cyclosm',
+    shortName: 'cyc',
     type: 'raster',
     url: [
         'https://a.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
@@ -80,6 +86,7 @@ const osmCycl: RasterStyle = {
 
 const omniscale: RasterStyle = {
     name: 'Omniscale',
+    shortName: 'oms',
     type: 'raster',
     url: [
         'https://maps.omniscale.net/v2/' + osApiKey + '/style.default/{z}/{x}/{y}.png' + (isRetina ? '?hq=true' : ''),
@@ -89,6 +96,7 @@ const omniscale: RasterStyle = {
 }
 const esriSatellite: RasterStyle = {
     name: 'Esri Satellite',
+    shortName: 'esri',
     type: 'raster',
     url: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
     attribution:
@@ -98,6 +106,7 @@ const esriSatellite: RasterStyle = {
 }
 const tfTransport: RasterStyle = {
     name: 'TF Transport',
+    shortName: 'tftransp',
     type: 'raster',
     url: [
         'https://a.tile.thunderforest.com/transport/{z}/{x}/{y}' + retina2x + '.png?apikey=' + thunderforestApiKey,
@@ -111,6 +120,7 @@ const tfTransport: RasterStyle = {
 }
 const tfCycle: RasterStyle = {
     name: 'TF Cycle',
+    shortName: 'tfcyc',
     type: 'raster',
     url: [
         'https://a.tile.thunderforest.com/cycle/{z}/{x}/{y}' + retina2x + '.png?apikey=' + thunderforestApiKey,
@@ -124,6 +134,7 @@ const tfCycle: RasterStyle = {
 }
 const tfOutdoors: RasterStyle = {
     name: 'TF Outdoors',
+    shortName: 'tfout',
     type: 'raster',
     url: [
         'https://a.tile.thunderforest.com/outdoors/{z}/{x}/{y}' + retina2x + '.png?apikey=' + thunderforestApiKey,
@@ -137,6 +148,7 @@ const tfOutdoors: RasterStyle = {
 }
 const mapillion: VectorStyle = {
     name: 'Mapilion',
+    shortName: 'mpln',
     type: 'vector',
     url: 'https://tiles.mapilion.com/assets/osm-bright/style.json?key=' + kurvigerApiKey,
     attribution:
@@ -145,6 +157,7 @@ const mapillion: VectorStyle = {
 }
 const wanderreitkarte: RasterStyle = {
     name: 'WanderReitKarte',
+    shortName: 'wrk',
     type: 'raster',
     url: [
         'https://topo.wanderreitkarte.de/topo/{z}/{x}/{y}.png',
@@ -192,7 +205,10 @@ export default class MapOptionsStore extends Store<MapOptionsStoreState> {
 
     reduce(state: MapOptionsStoreState, action: Action): MapOptionsStoreState {
         if (action instanceof SelectMapLayer) {
-            const styleOption = state.styleOptions.find(o => o.name === action.layer)
+            // Accept either the full name (legacy) or the short code used in share URLs.
+            const styleOption = state.styleOptions.find(
+                o => o.name === action.layer || o.shortName === action.layer,
+            )
             if (styleOption)
                 return {
                     ...state,

--- a/src/util/flexPolyline.ts
+++ b/src/util/flexPolyline.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ * Licensed under MIT, see full license in LICENSE
+ * SPDX-License-Identifier: MIT
+ * License-Filename: LICENSE
+ *
+ * Vendored verbatim (TypeScript-converted) from
+ *   https://github.com/heremaps/flexible-polyline/blob/master/javascript/index.js
+ * Algorithm bytes preserved unchanged. See /NOTICE.md for attribution.
+ */
+
+import { Coordinate } from '@/utils'
+
+const DEFAULT_PRECISION = 5
+
+const ENCODING_TABLE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+
+const DECODING_TABLE = [
+    62, -1, -1, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1,
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    22, 23, 24, 25, -1, -1, -1, -1, 63, -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+    36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+]
+
+const FORMAT_VERSION = 1
+
+export const ABSENT = 0
+export const LEVEL = 1
+export const ALTITUDE = 2
+export const ELEVATION = 3
+// Reserved values 4 and 5 should not be selectable
+export const CUSTOM1 = 6
+export const CUSTOM2 = 7
+
+// Use BigInt where available (modern browsers and Node) — keeps the algorithm
+// identical to the upstream reference; Number fallback handles the rest.
+const Num: any = typeof BigInt !== 'undefined' ? BigInt : Number
+
+export interface DecodeResult {
+    precision: number
+    thirdDim: number
+    thirdDimPrecision: number
+    polyline: number[][]
+}
+
+export interface EncodeParams {
+    precision?: number
+    thirdDim?: number
+    thirdDimPrecision?: number
+    polyline: number[][]
+}
+
+export function decode(encoded: string): DecodeResult {
+    const decoder = decodeUnsignedValues(encoded)
+    const header = decodeHeader(decoder[0], decoder[1])
+
+    const factorDegree = 10 ** header.precision
+    const factorZ = 10 ** header.thirdDimPrecision
+    const { thirdDim } = header
+
+    let lastLat = 0
+    let lastLng = 0
+    let lastZ = 0
+    const res: number[][] = []
+
+    let i = 2
+    for (; i < decoder.length; ) {
+        const deltaLat = toSigned(decoder[i])
+        const deltaLng = toSigned(decoder[i + 1])
+        lastLat += deltaLat
+        lastLng += deltaLng
+
+        if (thirdDim) {
+            const deltaZ = toSigned(decoder[i + 2])
+            lastZ += deltaZ
+            res.push([lastLat / factorDegree, lastLng / factorDegree, lastZ / factorZ])
+            i += 3
+        } else {
+            res.push([lastLat / factorDegree, lastLng / factorDegree])
+            i += 2
+        }
+    }
+
+    if (i !== decoder.length) {
+        throw new Error('Invalid encoding. Premature ending reached')
+    }
+
+    return {
+        ...header,
+        polyline: res,
+    }
+}
+
+function decodeChar(char: string): number {
+    const charCode = char.charCodeAt(0)
+    return DECODING_TABLE[charCode - 45]
+}
+
+function decodeUnsignedValues(encoded: string): any[] {
+    let result = Num(0)
+    let shift = Num(0)
+    const resList: any[] = []
+
+    encoded.split('').forEach(char => {
+        const value = Num(decodeChar(char))
+        result |= (value & Num(0x1f)) << shift
+        if ((value & Num(0x20)) === Num(0)) {
+            resList.push(result)
+            result = Num(0)
+            shift = Num(0)
+        } else {
+            shift += Num(5)
+        }
+    })
+
+    if (shift > 0) {
+        throw new Error('Invalid encoding')
+    }
+
+    return resList
+}
+
+function decodeHeader(version: any, encodedHeader: any) {
+    if (+version.toString() !== FORMAT_VERSION) {
+        throw new Error('Invalid format version')
+    }
+    const headerNumber = +encodedHeader.toString()
+    const precision = headerNumber & 15
+    const thirdDim = (headerNumber >> 4) & 7
+    const thirdDimPrecision = (headerNumber >> 7) & 15
+    return { precision, thirdDim, thirdDimPrecision }
+}
+
+function toSigned(val: any): number {
+    // Decode the sign from an unsigned value
+    let res = val
+    if (res & Num(1)) {
+        res = ~res
+    }
+    res >>= Num(1)
+    return +res.toString()
+}
+
+export function encode({
+    precision = DEFAULT_PRECISION,
+    thirdDim = ABSENT,
+    thirdDimPrecision = 0,
+    polyline,
+}: EncodeParams): string {
+    // Encode a sequence of lat,lng or lat,lng(,{third_dim}).
+    //   `precision`: how many decimal digits of precision to store the latitude and longitude.
+    //   `third_dim`: type of the third dimension if present in the input.
+    //   `third_dim_precision`: how many decimal digits of precision to store the third dimension.
+
+    const multiplierDegree = 10 ** precision
+    const multiplierZ = 10 ** thirdDimPrecision
+    const encodedHeaderList = encodeHeader(precision, thirdDim, thirdDimPrecision)
+    const encodedCoords: string[] = []
+
+    let lastLat = Num(0)
+    let lastLng = Num(0)
+    let lastZ = Num(0)
+    polyline.forEach(location => {
+        const lat = Num(Math.round(location[0] * multiplierDegree))
+        encodedCoords.push(encodeScaledValue(lat - lastLat))
+        lastLat = lat
+
+        const lng = Num(Math.round(location[1] * multiplierDegree))
+        encodedCoords.push(encodeScaledValue(lng - lastLng))
+        lastLng = lng
+
+        if (thirdDim) {
+            const z = Num(Math.round(location[2] * multiplierZ))
+            encodedCoords.push(encodeScaledValue(z - lastZ))
+            lastZ = z
+        }
+    })
+
+    return [...encodedHeaderList, ...encodedCoords].join('')
+}
+
+function encodeHeader(precision: number, thirdDim: number, thirdDimPrecision: number): string {
+    // Encode the `precision`, `third_dim` and `third_dim_precision` into one encoded char
+    if (precision < 0 || precision > 15) {
+        throw new Error('precision out of range. Should be between 0 and 15')
+    }
+    if (thirdDimPrecision < 0 || thirdDimPrecision > 15) {
+        throw new Error('thirdDimPrecision out of range. Should be between 0 and 15')
+    }
+    if (thirdDim < 0 || thirdDim > 7 || thirdDim === 4 || thirdDim === 5) {
+        throw new Error('thirdDim should be between 0, 1, 2, 3, 6 or 7')
+    }
+
+    const res = (thirdDimPrecision << 7) | (thirdDim << 4) | precision
+    return encodeUnsignedNumber(FORMAT_VERSION) + encodeUnsignedNumber(res)
+}
+
+function encodeUnsignedNumber(val: any): string {
+    // Uses variable integer encoding to encode an unsigned integer. Returns the encoded string.
+    let res = ''
+    let numVal = Num(val)
+    while (numVal > 0x1f) {
+        const pos = (numVal & Num(0x1f)) | Num(0x20)
+        res += ENCODING_TABLE[Number(pos)]
+        numVal >>= Num(5)
+    }
+    return res + ENCODING_TABLE[Number(numVal)]
+}
+
+function encodeScaledValue(value: any): string {
+    // Transform a integer `value` into a variable length sequence of characters.
+    let numVal = Num(value)
+    const negative = numVal < 0
+    numVal <<= Num(1)
+    if (negative) {
+        numVal = ~numVal
+    }
+
+    return encodeUnsignedNumber(numVal)
+}
+
+// ---------------------------------------------------------------------------
+// Thin wrappers for the GraphHopper Maps codebase:
+// convert between HERE's [lat, lng] tuples and our Coordinate { lat, lng }.
+
+// Default precision for share URLs — matches the rest of the codebase
+// (coordinateToText rounds to 1e-6; API uses points_encoded_multiplier 1e6).
+export const WAYPOINT_PRECISION = 6
+
+export function encodeCoords(coords: Coordinate[], precision = WAYPOINT_PRECISION): string {
+    return encode({
+        precision,
+        polyline: coords.map(c => [c.lat, c.lng]),
+    })
+}
+
+export function decodeCoords(encoded: string): Coordinate[] {
+    return decode(encoded).polyline.map(([lat, lng]) => ({ lat, lng }))
+}

--- a/src/util/flexPolyline.ts
+++ b/src/util/flexPolyline.ts
@@ -1,12 +1,33 @@
 /*
  * Copyright (C) 2019 HERE Europe B.V.
- * Licensed under MIT, see full license in LICENSE
+ * Licensed under MIT; the full license text for this vendored file is reproduced
+ * below.
  * SPDX-License-Identifier: MIT
- * License-Filename: LICENSE
+ * License-Filename: src/util/flexPolyline.ts
  *
  * Vendored verbatim (TypeScript-converted) from
  *   https://github.com/heremaps/flexible-polyline/blob/master/javascript/index.js
  * Algorithm bytes preserved unchanged. See /NOTICE.md for attribution.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 import { Coordinate } from '@/utils'

--- a/src/util/urlCompress.ts
+++ b/src/util/urlCompress.ts
@@ -1,0 +1,63 @@
+// Small helpers wrapping the browser-native CompressionStream API for use in
+// share URLs. Uses 'deflate-raw' (no zlib/gzip framing → smallest output) plus
+// base64url so the result is safe to drop straight into a URLSearchParam value
+// without any percent-encoding overhead.
+
+export function canCompress(): boolean {
+    return typeof CompressionStream !== 'undefined' && typeof DecompressionStream !== 'undefined'
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+    let bin = ''
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+    return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+    const padLen = (4 - (s.length % 4)) % 4
+    const padded = s.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat(padLen)
+    const bin = atob(padded)
+    const out = new Uint8Array(bin.length)
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+    return out
+}
+
+async function streamThrough(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+    const reader = stream.getReader()
+    const chunks: Uint8Array[] = []
+    let total = 0
+    while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        chunks.push(value)
+        total += value.length
+    }
+    const out = new Uint8Array(total)
+    let off = 0
+    for (const c of chunks) {
+        out.set(c, off)
+        off += c.length
+    }
+    return out
+}
+
+function bytesAsReadableStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+    return new ReadableStream({
+        start(controller) {
+            controller.enqueue(bytes)
+            controller.close()
+        },
+    })
+}
+
+export async function deflateB64url(input: string): Promise<string> {
+    const bytes = new TextEncoder().encode(input)
+    const compressed = (bytesAsReadableStream(bytes) as any).pipeThrough(new CompressionStream('deflate-raw'))
+    return bytesToBase64Url(await streamThrough(compressed))
+}
+
+export async function inflateB64url(input: string): Promise<string> {
+    const bytes = base64UrlToBytes(input)
+    const decompressed = (bytesAsReadableStream(bytes) as any).pipeThrough(new DecompressionStream('deflate-raw'))
+    return new TextDecoder().decode(await streamThrough(decompressed))
+}

--- a/test/NavBar.test.ts
+++ b/test/NavBar.test.ts
@@ -30,6 +30,7 @@ import Dispatcher from '@/stores/Dispatcher'
 import { coordinateToText } from '@/Converters'
 import { encodeCoords } from '@/util/flexPolyline'
 import { deflateB64url } from '@/util/urlCompress'
+import * as urlCompress from '@/util/urlCompress'
 
 // import the window and mock it with jest
 import { window } from '@/Window'
@@ -399,6 +400,34 @@ describe('NavBar', function () {
 
             expect(queryStore.state.routingProfile.name).toEqual('some-profile-name')
         })
+    })
+
+    it('does not let an older URL build overwrite a newer one when compressions complete out of order', async () => {
+        // Two synchronous dispatches each kick off an async URL build. We force
+        // the older build to finish *after* the newer one. Without the urlChangeId
+        // guard the stale build's pushState would clobber the current URL.
+        let resolveOld: (s: string) => void = () => {}
+        let resolveNew: (s: string) => void = () => {}
+        const spy = jest
+            .spyOn(urlCompress, 'deflateB64url')
+            .mockImplementationOnce(() => new Promise<string>(r => (resolveOld = r)))
+            .mockImplementationOnce(() => new Promise<string>(r => (resolveNew = r)))
+
+        try {
+            queryStore.receive(new SetCustomModel('{"distance_influence":1}', true))
+            queryStore.receive(new SetCustomModel('{"distance_influence":2}', true))
+
+            // Resolve the newer build first, then the older one — the older one
+            // returning last is exactly the race we're guarding against.
+            resolveNew('NEW')
+            await flush()
+            resolveOld('OLD')
+            await flush()
+
+            expect(lastPushedUrl().searchParams.get('cmodel')).toEqual('NEW')
+        } finally {
+            spy.mockRestore()
+        }
     })
 
     it('updates query store state on popstate (back-pressed)', async () => {

--- a/test/NavBar.test.ts
+++ b/test/NavBar.test.ts
@@ -292,7 +292,8 @@ describe('NavBar', function () {
             await navBar.updateStateFromUrl()
 
             expect(queryStore.state.customModelEnabled).toEqual(true)
-            expect(queryStore.state.customModelStr).toEqual(cm)
+            // stored value is pretty-printed, so compare JSON semantically
+            expect(JSON.parse(queryStore.state.customModelStr)).toEqual(JSON.parse(cm))
         })
 
         it('parses legacy custom_model= URL', async () => {
@@ -308,7 +309,7 @@ describe('NavBar', function () {
             await navBar.updateStateFromUrl()
 
             expect(queryStore.state.customModelEnabled).toEqual(true)
-            expect(queryStore.state.customModelStr).toEqual(cm)
+            expect(JSON.parse(queryStore.state.customModelStr)).toEqual(JSON.parse(cm))
         })
 
         it('sets no points when no points are in URL', async () => {

--- a/test/NavBar.test.ts
+++ b/test/NavBar.test.ts
@@ -1,15 +1,41 @@
+// We use jsdom (some imported modules touch window at load) but jsdom doesn't
+// expose CompressionStream / Blob globally — pull them in from Node so the
+// compression code paths can be exercised. Localized here so we don't need a
+// jest setup file.
+if (typeof (globalThis as any).CompressionStream === 'undefined') {
+    const sw = require('stream/web')
+    ;(globalThis as any).CompressionStream = sw.CompressionStream
+    ;(globalThis as any).DecompressionStream = sw.DecompressionStream
+    ;(globalThis as any).ReadableStream = sw.ReadableStream
+    ;(globalThis as any).WritableStream = sw.WritableStream
+    ;(globalThis as any).TransformStream = sw.TransformStream
+}
+if (typeof (globalThis as any).TextEncoder === 'undefined') {
+    const util = require('util')
+    ;(globalThis as any).TextEncoder = util.TextEncoder
+    ;(globalThis as any).TextDecoder = util.TextDecoder
+}
+
 import NavBar from '@/NavBar'
 import QueryStore, { QueryPoint, QueryPointType } from '@/stores/QueryStore'
 import DummyApi from './DummyApi'
-import { SelectMapLayer, SetPoint, SetVehicleProfile } from '@/actions/Actions'
+import {
+    SelectMapLayer,
+    SetCustomModel,
+    SetCustomModelEnabled,
+    SetPoint,
+    SetQueryPoints,
+    SetVehicleProfile,
+} from '@/actions/Actions'
 import Dispatcher from '@/stores/Dispatcher'
 import { coordinateToText } from '@/Converters'
+import { encodeCoords } from '@/util/flexPolyline'
+import { deflateB64url } from '@/util/urlCompress'
 
 // import the window and mock it with jest
 import { window } from '@/Window'
 import MapOptionsStore from '@/stores/MapOptionsStore'
 import * as config from 'config'
-import { RoutingProfile } from '@/api/graphhopper'
 
 jest.mock('@/Window', () => ({
     window: {
@@ -24,6 +50,26 @@ jest.mock('@/Window', () => ({
         addEventListener: jest.fn(),
     },
 }))
+
+// Flush pending microtasks + macrotask ticks so async URL updates settle.
+// CompressionStream involves several stream-pipe hops, so we wait a few ticks.
+async function flush() {
+    for (let i = 0; i < 5; i++) await new Promise(r => setTimeout(r, 0))
+}
+
+// Helper to build N initialized query points. QueryStore starts with 2 default
+// empty points; for N>2 we need to replace the whole array via SetQueryPoints
+// since SetPoint only replaces an existing point by id.
+function makePoints(defs: { lat: number; lng: number; text?: string }[]): QueryPoint[] {
+    return defs.map((d, i) => ({
+        coordinate: { lat: d.lat, lng: d.lng },
+        queryText: d.text ?? coordinateToText({ lat: d.lat, lng: d.lng }),
+        isInitialized: true,
+        id: i,
+        color: '',
+        type: QueryPointType.Via,
+    }))
+}
 
 describe('NavBar', function () {
     let queryStore: QueryStore
@@ -51,69 +97,107 @@ describe('NavBar', function () {
         Dispatcher.clear()
     })
 
+    function lastPushedUrl(): URL {
+        const calls = (window.history.pushState as jest.Mock).mock.calls
+        return new URL(calls[calls.length - 1][2])
+    }
+
     describe('state to url', () => {
-        it('should convert query store state into url params on change', function () {
-            const coordinates = [
+        it('emits legacy point= for 2-3 initialized points (below fpolyline threshold)', async () => {
+            queryStore.receive(new SetQueryPoints(makePoints([{ lat: 1, lng: 2 }, { lat: 10, lng: 10 }])))
+            queryStore.receive(new SetVehicleProfile({ name: 'car' }))
+            mapStore.receive(new SelectMapLayer('Cyclosm'))
+            await flush()
+
+            const url = lastPushedUrl()
+            expect(url.searchParams.has('fpolyline')).toEqual(false)
+            expect(url.searchParams.getAll('point')).toEqual(['1,2', '10,10'])
+        })
+
+        it('emits fpolyline (no names) for 4+ initialized points', async () => {
+            const coords = [
                 { lat: 1, lng: 2 },
-                { lat: 10, lng: 10 },
+                { lat: 3, lng: 4 },
+                { lat: 5, lng: 6 },
+                { lat: 7, lng: 8 },
             ]
-            const points = coordinates.map((c, i) => {
-                return {
-                    ...queryStore.state.queryPoints[i],
-                    coordinate: c,
-                    queryText: coordinateToText(c),
-                    isInitialized: true,
-                }
-            })
+            queryStore.receive(new SetQueryPoints(makePoints(coords)))
+            queryStore.receive(new SetVehicleProfile({ name: 'car' }))
+            mapStore.receive(new SelectMapLayer('Cyclosm'))
+            await flush()
 
-            testCreateUrl(points, { name: 'my-profile' }, 'Cyclosm')
+            const url = lastPushedUrl()
+            expect(url.searchParams.get('fpolyline')).toEqual(encodeCoords(coords))
+            expect(url.searchParams.has('cnames')).toEqual(false)
+            expect(url.searchParams.getAll('point').length).toEqual(0)
         })
 
-        it('should convert query store state into url params on change including addresses', () => {
-            const points = [
-                { lat: 1, lng: 2, text: 'som3, address with ! some, characters-in it' },
-                { lat: 10, lng: 10, text: 'some_?more>characters' },
-            ].map((point, i) => {
-                return {
-                    ...queryStore.state.queryPoints[i],
-                    coordinate: { lat: point.lat, lng: point.lng },
-                    queryText: point.text,
-                    isInitialized: true,
-                }
-            })
+        it('emits fpolyline + cnames (always compressed) when any of the 4+ points has a custom name', async () => {
+            queryStore.receive(
+                new SetQueryPoints(
+                    makePoints([
+                        { lat: 1, lng: 2, text: 'Berlin' },
+                        { lat: 3, lng: 4 },
+                        { lat: 5, lng: 6, text: 'Paris' },
+                        { lat: 7, lng: 8 },
+                    ]),
+                ),
+            )
+            queryStore.receive(new SetVehicleProfile({ name: 'car' }))
+            mapStore.receive(new SelectMapLayer('Cyclosm'))
+            await flush()
 
-            testCreateUrl(points, { name: 'my-profile' }, 'Cyclosm')
+            const url = lastPushedUrl()
+            expect(url.searchParams.has('fpolyline')).toEqual(true)
+            expect(url.searchParams.has('cnames')).toEqual(true)
+            expect(url.searchParams.has('name')).toEqual(false)
         })
 
-        function testCreateUrl(points: QueryPoint[], profile: RoutingProfile, layer: string) {
-            // build url which we expect at the end
-            const expectedUrl = new URL(window.location.origin + window.location.pathname)
-            for (const point of points) {
-                const coordinate = coordinateToText(point.coordinate)
-                const param = coordinate === point.queryText ? coordinate : coordinate + '_' + point.queryText
-                expectedUrl.searchParams.append('point', param)
-            }
-            expectedUrl.searchParams.append('profile', profile.name)
-            expectedUrl.searchParams.append('layer', layer)
+        it('falls back to legacy point= when not all points are initialized', async () => {
+            const existing = queryStore.state.queryPoints[0]
+            queryStore.receive(
+                new SetPoint(
+                    { ...existing, coordinate: { lat: 11, lng: 12 }, queryText: '11,12', isInitialized: true },
+                    true,
+                ),
+            )
+            queryStore.receive(new SetVehicleProfile({ name: 'car' }))
+            mapStore.receive(new SelectMapLayer('Cyclosm'))
+            await flush()
 
-            // modify state of stores which the nav bar depends on
-            for (const point of points) {
-                queryStore.receive(new SetPoint(point, true))
-            }
-            queryStore.receive(new SetVehicleProfile(profile))
-            mapStore.receive(new SelectMapLayer(layer))
+            const url = lastPushedUrl()
+            expect(url.searchParams.has('fpolyline')).toEqual(false)
+            expect(url.searchParams.getAll('point').length).toEqual(2)
+        })
 
-            // make assertions
-            // number of calls profile, style and how many points there are
-            const numberOfCalls = 2 + points.length
-            expect(window.history.pushState).toHaveBeenCalledTimes(numberOfCalls)
-            expect(window.history.pushState).toHaveBeenNthCalledWith(numberOfCalls, null, '', expectedUrl.toString())
-        }
+        it('emits l=<shortName> (not layer=<fullName>) for the selected map style', async () => {
+            queryStore.receive(new SetQueryPoints(makePoints([{ lat: 1, lng: 2 }, { lat: 10, lng: 10 }])))
+            queryStore.receive(new SetVehicleProfile({ name: 'car' }))
+            mapStore.receive(new SelectMapLayer('Omniscale'))
+            await flush()
+
+            const url = lastPushedUrl()
+            expect(url.searchParams.get('l')).toEqual('oms')
+            expect(url.searchParams.has('layer')).toEqual(false)
+        })
+
+        it('always emits cmodel (compressed) when custom model is enabled', async () => {
+            const cm = '{"distance_influence":15}'
+            queryStore.receive(new SetQueryPoints(makePoints([{ lat: 1, lng: 2 }, { lat: 10, lng: 10 }])))
+            queryStore.receive(new SetVehicleProfile({ name: 'car' }))
+            mapStore.receive(new SelectMapLayer('Cyclosm'))
+            queryStore.receive(new SetCustomModel(cm, true))
+            queryStore.receive(new SetCustomModelEnabled(true))
+            await flush()
+
+            const url = lastPushedUrl()
+            expect(url.searchParams.has('cmodel')).toEqual(true)
+            expect(url.searchParams.has('custom_model')).toEqual(false)
+        })
     })
 
     describe('url to state', () => {
-        it('should parse the url and create a new query state when triggered from outside', () => {
-            // set up data
+        it('parses legacy point=lat,lng_name URLs', async () => {
             const point: QueryPoint = {
                 coordinate: { lat: 1, lng: 1 },
                 id: 0,
@@ -122,153 +206,203 @@ describe('NavBar', function () {
                 queryText: 'some1address-with!/<symb0ls',
                 color: '',
             }
-            const profile = 'some-profile'
-            const layer = 'Omniscale'
             const url = new URL(window.location.origin + window.location.pathname)
             url.searchParams.append('point', coordinateToText(point.coordinate) + '_' + point.queryText)
-            url.searchParams.append('profile', profile)
-            url.searchParams.append('layer', layer)
-
+            url.searchParams.append('profile', 'some-profile')
+            url.searchParams.append('layer', 'Omniscale')
             window.location.href = url.toString()
 
-            // act
-            navBar.updateStateFromUrl()
+            await navBar.updateStateFromUrl()
 
-            //assert
             expect(queryStore.state.queryPoints.length).toEqual(2)
             expect(queryStore.state.queryPoints[0].coordinate).toEqual(point.coordinate)
             expect(queryStore.state.queryPoints[0].isInitialized).toEqual(true)
             expect(queryStore.state.queryPoints[0].queryText).toEqual(point.queryText)
-            expect(queryStore.state.queryPoints[1].coordinate).toEqual({ lat: 0, lng: 0 })
-            expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
-            expect(queryStore.state.routingProfile.name).toEqual(profile)
-
-            expect(mapStore.state.selectedStyle.name).toEqual(layer)
-
-            // make sure the navbar doesn't change the window's location while parsing
-            expect(url.toString()).toEqual(window.location.href)
+            expect(queryStore.state.routingProfile.name).toEqual('some-profile')
+            expect(mapStore.state.selectedStyle.name).toEqual('Omniscale')
         })
 
-        it('should parse the url and set no points when no points are set', () => {
+        it('parses fpolyline URL roundtrip', async () => {
+            const coords = [
+                { lat: 51.106229, lng: 13.679849 },
+                { lat: 51.049329, lng: 13.738144 },
+                { lat: 50.987800, lng: 13.687515 },
+                { lat: 50.876543, lng: 13.512345 },
+            ]
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('fpolyline', encodeCoords(coords))
+            url.searchParams.append('profile', 'car')
+            url.searchParams.append('layer', 'Omniscale')
+            window.location.href = url.toString()
+
+            await navBar.updateStateFromUrl()
+
+            expect(queryStore.state.queryPoints.length).toEqual(coords.length)
+            for (let i = 0; i < coords.length; i++) {
+                expect(queryStore.state.queryPoints[i].coordinate.lat).toBeCloseTo(coords[i].lat, 6)
+                expect(queryStore.state.queryPoints[i].coordinate.lng).toBeCloseTo(coords[i].lng, 6)
+                expect(queryStore.state.queryPoints[i].isInitialized).toEqual(true)
+            }
+        })
+
+        it('parses fpolyline + cnames URL (and roundtrip strips * from names on write)', async () => {
+            const coords = [
+                { lat: 1, lng: 2 },
+                { lat: 3, lng: 4 },
+                { lat: 5, lng: 6 },
+                { lat: 7, lng: 8 },
+            ]
+            const cnames = await deflateB64url('München*Wien*Krakow*Prague')
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('fpolyline', encodeCoords(coords))
+            url.searchParams.append('cnames', cnames)
+            url.searchParams.append('profile', 'car')
+            url.searchParams.append('layer', 'Omniscale')
+            window.location.href = url.toString()
+
+            await navBar.updateStateFromUrl()
+
+            expect(queryStore.state.queryPoints.map(p => p.queryText)).toEqual(['München', 'Wien', 'Krakow', 'Prague'])
+
+            // Inject a '*' into one queryText and verify it gets stripped on re-emission.
+            queryStore.receive(
+                new SetPoint(
+                    { ...queryStore.state.queryPoints[0], queryText: 'A*star', isInitialized: true },
+                    true,
+                ),
+            )
+            await flush()
+            const reEmitted = lastPushedUrl()
+            window.location.href = reEmitted.toString()
+            await navBar.updateStateFromUrl()
+            expect(queryStore.state.queryPoints[0].queryText).toEqual('Astar')
+        })
+
+        it('parses cmodel (compressed custom model) URL', async () => {
+            const cm = '{"distance_influence":15,"priority":[],"speed":[],"areas":{}}'
+            const cmodel = await deflateB64url(cm)
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('point', '1,2')
+            url.searchParams.append('point', '3,4')
+            url.searchParams.append('cmodel', cmodel)
+            url.searchParams.append('profile', 'car')
+            url.searchParams.append('layer', 'Omniscale')
+            window.location.href = url.toString()
+
+            await navBar.updateStateFromUrl()
+
+            expect(queryStore.state.customModelEnabled).toEqual(true)
+            expect(queryStore.state.customModelStr).toEqual(cm)
+        })
+
+        it('parses legacy custom_model= URL', async () => {
+            const cm = '{"distance_influence":15}'
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('point', '1,2')
+            url.searchParams.append('point', '3,4')
+            url.searchParams.append('custom_model', cm)
+            url.searchParams.append('profile', 'car')
+            url.searchParams.append('layer', 'Omniscale')
+            window.location.href = url.toString()
+
+            await navBar.updateStateFromUrl()
+
+            expect(queryStore.state.customModelEnabled).toEqual(true)
+            expect(queryStore.state.customModelStr).toEqual(cm)
+        })
+
+        it('sets no points when no points are in URL', async () => {
             window.location.href = 'https://origin.com'
             const point1 = queryStore.state.queryPoints[0]
             const point2 = queryStore.state.queryPoints[1]
 
-            // act
-            navBar.updateStateFromUrl()
+            await navBar.updateStateFromUrl()
 
-            //assert
-            // we still want to have 2 points and they should have the same values as before - the ids are changed though
-            // since the store creates new instances of points regardless what is fed with "setallqyeryparamsatonce"
             expect(queryStore.state.queryPoints.length).toEqual(2)
             expect(queryStore.state.queryPoints[0].coordinate).toEqual(point1.coordinate)
             expect(queryStore.state.queryPoints[1].coordinate).toEqual(point2.coordinate)
-            expect(queryStore.state.queryPoints[0].queryText).toEqual(point1.queryText)
-            expect(queryStore.state.queryPoints[1].queryText).toEqual(point2.queryText)
         })
 
-        it('should parse the url and only skip invalid points', () => {
-            const expectedUrl = 'https://current.origin/?point=&point=11%2C12'
-            window.location.href = expectedUrl
+        it('only skips invalid legacy point= entries, and re-emits the URL unchanged on roundtrip', async () => {
+            const inputUrl = 'https://current.origin/?point=&point=11%2C12'
+            window.location.href = inputUrl
 
-            // act
-            navBar.updateStateFromUrl()
+            await navBar.updateStateFromUrl()
 
-            //assert
             expect(queryStore.state.queryPoints.length).toEqual(2)
             expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
             expect(queryStore.state.queryPoints[0].queryText).toEqual('')
             expect(queryStore.state.queryPoints[1].coordinate).toEqual({ lat: 11, lng: 12 })
             expect(queryStore.state.queryPoints[1].isInitialized).toEqual(true)
 
-            // make sure the navbar doesn't change the window's location while parsing
-            expect(expectedUrl).toEqual(window.location.href)
-            expect(window.history.pushState).toHaveBeenCalledTimes(0)
+            // parsing must not change the URL bar
+            expect(window.location.href).toEqual(inputUrl)
 
-            navBar.updateUrlFromState()
-            expect(window.history.pushState).toHaveBeenNthCalledWith(
-                1,
-                null,
-                '',
-                expectedUrl + '&profile=&layer=OpenStreetMap',
-            )
+            // re-emit and verify the URL is stable (profile + layer-short-code appended)
+            await navBar.updateUrlFromState()
+            expect(window.history.pushState).toHaveBeenLastCalledWith(null, '', inputUrl + '&profile=&l=osm')
         })
 
-        it('should parse the url and invalidate old points', () => {
+        it('invalidates old points when URL has none', async () => {
             window.location.href = 'https://origin.com'
-            Dispatcher.dispatch(
-                new SetPoint(
-                    {
-                        ...queryStore.state.queryPoints[0],
-                        isInitialized: true,
-                    },
-                    true,
-                ),
-            )
+            Dispatcher.dispatch(new SetPoint({ ...queryStore.state.queryPoints[0], isInitialized: true }, true))
 
-            //act
-            navBar.updateStateFromUrl()
+            await navBar.updateStateFromUrl()
 
-            // assert
-            expect(queryStore.state.queryPoints.length).toEqual(2)
             expect(queryStore.state.queryPoints[0].isInitialized).toBeFalsy()
             expect(queryStore.state.queryPoints[1].isInitialized).toBeFalsy()
         })
 
-        it('should parse the url and set defaults for layer if not provided', () => {
+        it('uses default layer when not provided', async () => {
             window.location.href = 'https://origin.com'
 
-            // act
-            navBar.updateStateFromUrl()
+            await navBar.updateStateFromUrl()
 
-            //assert
-            expect(queryStore.state.queryPoints.length).toEqual(2)
-            expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
-            expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
             expect(queryStore.state.routingProfile.name).toEqual('')
-
             expect(mapStore.state.selectedStyle.name).toEqual(config.defaultTiles)
         })
 
-        it('should parse the url and set defaults for profile if not set', () => {
-            const layername = 'Omniscale'
+        it('keeps the current routing profile when the URL has no profile param', async () => {
             const url = new URL(window.location.origin + window.location.pathname)
-            url.searchParams.append('layer', layername)
+            url.searchParams.append('layer', 'Omniscale')
             window.location.href = url.toString()
 
             Dispatcher.dispatch(new SetVehicleProfile({ name: 'some-profile' }))
             const defaultProfile = queryStore.state.routingProfile
 
-            // act
-            navBar.updateStateFromUrl()
+            await navBar.updateStateFromUrl()
 
-            //assert
-            expect(queryStore.state.queryPoints.length).toEqual(2)
-            expect(queryStore.state.queryPoints[0].isInitialized).toEqual(false)
-            expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
             expect(queryStore.state.routingProfile.name).toEqual(defaultProfile.name)
-            expect(mapStore.state.selectedStyle.name).toEqual(layername)
+            expect(mapStore.state.selectedStyle.name).toEqual('Omniscale')
         })
 
-        it('should parse the url and set routing profile for legacy "vehicle" param', () => {
-            const layername = 'Omniscale'
-            const profileName = 'some-profile-name'
-            const url = new URL(window.location.origin + window.location.pathname)
-            url.searchParams.append('layer', layername)
-            url.searchParams.append('vehicle', profileName)
+        it('parses the new short layer code (l=oms) and the legacy layer=<fullName> form', async () => {
+            const urlShort = new URL(window.location.origin + window.location.pathname)
+            urlShort.searchParams.append('l', 'oms')
+            window.location.href = urlShort.toString()
+            await navBar.updateStateFromUrl()
+            expect(mapStore.state.selectedStyle.name).toEqual('Omniscale')
 
+            const urlLegacy = new URL(window.location.origin + window.location.pathname)
+            urlLegacy.searchParams.append('layer', 'Cyclosm')
+            window.location.href = urlLegacy.toString()
+            await navBar.updateStateFromUrl()
+            expect(mapStore.state.selectedStyle.name).toEqual('Cyclosm')
+        })
+
+        it('supports the legacy "vehicle" param as profile', async () => {
+            const url = new URL(window.location.origin + window.location.pathname)
+            url.searchParams.append('layer', 'Omniscale')
+            url.searchParams.append('vehicle', 'some-profile-name')
             window.location.href = url.toString()
 
-            // act
-            navBar.updateStateFromUrl()
+            await navBar.updateStateFromUrl()
 
-            // assert
-            expect(queryStore.state.routingProfile.name).toEqual(profileName)
+            expect(queryStore.state.routingProfile.name).toEqual('some-profile-name')
         })
     })
 
-    it('should update the query store state on popstate (back-pressed)', () => {
-        // set up data
+    it('updates query store state on popstate (back-pressed)', async () => {
         const point: QueryPoint = {
             coordinate: { lat: 1, lng: 1 },
             id: 0,
@@ -277,29 +411,18 @@ describe('NavBar', function () {
             queryText: '',
             color: '',
         }
-        const profile = 'some-profile'
-        const layer = 'Omniscale'
         const url = new URL(window.location.origin + window.location.pathname)
         url.searchParams.append('point', coordinateToText(point.coordinate))
-        url.searchParams.append('profile', profile)
-        url.searchParams.append('layer', layer)
-
+        url.searchParams.append('profile', 'some-profile')
+        url.searchParams.append('layer', 'Omniscale')
         window.location.href = url.toString()
 
-        // act
-        callbacks.forEach(callback => callback('popstate'))
+        await Promise.all(callbacks.map(callback => callback('popstate')))
+        await flush()
 
-        // assert
-        expect(queryStore.state.queryPoints.length).toEqual(2)
         expect(queryStore.state.queryPoints[0].coordinate).toEqual(point.coordinate)
         expect(queryStore.state.queryPoints[0].isInitialized).toEqual(true)
-        expect(queryStore.state.queryPoints[1].coordinate).toEqual({ lat: 0, lng: 0 })
-        expect(queryStore.state.queryPoints[1].isInitialized).toEqual(false)
-        expect(queryStore.state.routingProfile.name).toEqual(profile)
-
-        expect(mapStore.state.selectedStyle.name).toEqual(layer)
-
-        // make sure the navbar doesn't change the window's location while parsing
-        expect(url.toString()).toEqual(window.location.href)
+        expect(queryStore.state.routingProfile.name).toEqual('some-profile')
+        expect(mapStore.state.selectedStyle.name).toEqual('Omniscale')
     })
 })

--- a/test/flexPolyline.test.ts
+++ b/test/flexPolyline.test.ts
@@ -1,0 +1,63 @@
+import { decode, decodeCoords, encode, encodeCoords, WAYPOINT_PRECISION } from '@/util/flexPolyline'
+
+// Canonical test vector from HERE's reference README:
+//   https://github.com/heremaps/flexible-polyline
+// Ensures bit-exact compatibility with the upstream reference implementation.
+const REFERENCE_INPUT: number[][] = [
+    [50.1022829, 8.6982122],
+    [50.1020076, 8.6956695],
+    [50.1006313, 8.691496],
+    [50.0987800, 8.6875156],
+]
+const REFERENCE_OUTPUT = 'BFoz5xJ67i1B1B7PzIhaxL7Y'
+
+describe('flexPolyline (HERE reference)', () => {
+    it('encodes the canonical README example bit-exactly', () => {
+        const encoded = encode({ precision: 5, polyline: REFERENCE_INPUT })
+        expect(encoded).toEqual(REFERENCE_OUTPUT)
+    })
+
+    it('decodes the canonical README example bit-exactly', () => {
+        const decoded = decode(REFERENCE_OUTPUT)
+        expect(decoded.precision).toEqual(5)
+        expect(decoded.thirdDim).toEqual(0)
+        for (let i = 0; i < REFERENCE_INPUT.length; i++) {
+            expect(decoded.polyline[i][0]).toBeCloseTo(REFERENCE_INPUT[i][0], 5)
+            expect(decoded.polyline[i][1]).toBeCloseTo(REFERENCE_INPUT[i][1], 5)
+        }
+    })
+})
+
+describe('flexPolyline Coordinate wrapper', () => {
+    it('roundtrips Coordinate arrays losslessly at precision 6', () => {
+        const coords = [
+            { lat: 51.106229, lng: 13.679849 },
+            { lat: 51.049329, lng: 13.738144 },
+            { lat: 55.72172, lng: 21.950163 },
+            { lat: -33.86882, lng: 151.20929 },
+        ]
+        const encoded = encodeCoords(coords)
+        const decoded = decodeCoords(encoded)
+        expect(decoded.length).toEqual(coords.length)
+        for (let i = 0; i < coords.length; i++) {
+            expect(decoded[i].lat).toBeCloseTo(coords[i].lat, 6)
+            expect(decoded[i].lng).toBeCloseTo(coords[i].lng, 6)
+        }
+    })
+
+    it('uses precision 6 by default (matches coordinateToText precision)', () => {
+        const coords = [{ lat: 51.123456, lng: 13.987654 }]
+        const encoded = encodeCoords(coords)
+        // Decoded header should carry precision 6
+        expect(decode(encoded).precision).toEqual(WAYPOINT_PRECISION)
+    })
+
+    it('produces a URL-safe string (only A-Za-z0-9_- chars)', () => {
+        const coords = [
+            { lat: 51.106229, lng: 13.679849 },
+            { lat: 51.049329, lng: 13.738144 },
+        ]
+        const encoded = encodeCoords(coords)
+        expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/)
+    })
+})

--- a/test/urlCompress.test.ts
+++ b/test/urlCompress.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+// Use Node's environment because jsdom doesn't ship CompressionStream / Blob.
+import { canCompress, deflateB64url, inflateB64url } from '@/util/urlCompress'
+
+describe('urlCompress', () => {
+    it('feature-detect works under Node (CompressionStream is global since v18)', () => {
+        expect(canCompress()).toBe(true)
+    })
+
+    it('roundtrips a typical custom_model JSON and outputs URL-safe chars', async () => {
+        const input =
+            '{"distance_influence":15,"priority":[{"if":"road_environment==FERRY","multiply_by":"0.9"}],"speed":[],"areas":{"type":"FeatureCollection","features":[]}}'
+        const compressed = await deflateB64url(input)
+        expect(compressed).toMatch(/^[A-Za-z0-9_-]+$/)
+        expect(await inflateB64url(compressed)).toEqual(input)
+    })
+
+    it('produces a smaller output than the raw URL-encoded input for redundant payloads', async () => {
+        // A larger custom_model with repeated keys / structure — the case where
+        // compression actually pays off (the bloat-fallback in NavBar handles
+        // the small-input case where it doesn't).
+        const heavy = JSON.stringify({
+            distance_influence: 15,
+            priority: Array(20).fill({ if: 'road_environment==FERRY', multiply_by: '0.9' }),
+            speed: [],
+            areas: { type: 'FeatureCollection', features: [] },
+        })
+        const compressed = await deflateB64url(heavy)
+        expect(compressed.length).toBeLessThan(heavy.length)
+        expect(await inflateB64url(compressed)).toEqual(heavy)
+    })
+
+    it('roundtrips a *-joined names list with non-ASCII characters', async () => {
+        const input = 'München*Wien*Brandenburger Tor, 10117 Berlin, Germany*Krakow'
+        const compressed = await deflateB64url(input)
+        const decompressed = await inflateB64url(compressed)
+        expect(decompressed).toEqual(input)
+    })
+
+    it('roundtrips an empty string', async () => {
+        const compressed = await deflateB64url('')
+        const decompressed = await inflateB64url(compressed)
+        expect(decompressed).toEqual('')
+    })
+})


### PR DESCRIPTION
Try [here](https://graphhopper.com/maps-dev/shorter_url/?profile=car&l=oms).

Especially for many way points or with a `custom_model` the URL length can get very long. This change uses [the flex polyline algorithm from HERE](https://github.com/heremaps/flexible-polyline) to reduce length for `point=` (starting with 4 points) and creates a new parameter `fpolyline`. It also compresses the text of the points and the custom model parameter.

E.g. with 7 points the following URL with 147 characters:

```
fpolyline=BGqgunhDgwkhVzk5C-2gGrw5B4tqDu3xBqh5YzlwJlt0Jj5-E3pN9sjFhrkD&cnames=cy1KKy0q0VEIySgtysxLz0zUUXBPLcpNzKvU0tLySs1LxCEFAA&profile=car&l=oms
```

is equivalent to this URL with 283 characters:

```
point=50.977797%2C11.028736_Erfurt%2C+Thuringia%2C+Germany&point=50.932155%2C11.127407&point=50.902709%2C11.181899&point=50.928172%2C11.587936_Jena%2C+Thuringia%2C+Germany&point=50.772434%2C11.430029&point=50.691136%2C11.423217&point=50.607473%2C11.37184&profile=car&layer=Omniscale
```

Or here for a simple custom model that uses an area (210 vs. 444 chars):

```
cmodel=bY3BCoMwDIbfJeciK1MEr4Odd5ciVaMEqpEaD0V8d0s32AZCLt-fP192WDyxJwlQ1TvQABXQ3HQs0m4rKJg2J7S40LSxATc4jALr0a5Q7SBhwZg-0crm8cHOYSfEc7wb3tmatP-9uKU-4vfJiDyh-PDjfLELYzJ1zL6n2UqS1bXOs7tWhc7KwqhE-QWVH9IXVBhjjiPOCQ
custom_model=%7B%22priority%22%3A%5B%7B%22if%22%3A%22in_cottbus%22%2C%22multiply_by%22%3A%220%22%7D%5D%2C%22areas%22%3A%7B%22type%22%3A%22FeatureCollection%22%2C%22features%22%3A%5B%7B%22type%22%3A%22Feature%22%2C%22id%22%3A%22cottbus%22%2C%22geometry%22%3A%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B14.31%2C51.75%5D%2C%5B14.34%2C51.75%5D%2C%5B14.34%2C51.77%5D%2C%5B14.31%2C51.77%5D%2C%5B14.31%2C51.75%5D%5D%5D%7D%7D%5D%7D%7D
```

For smaller custom models that just exclude the motorway it is still a nice improvement (95 vs. 122):

```
cmodel=q1YqKMrML8osqVSyiq5WykxTslIqyk9MiU_OSSwutrX19Q_xDwp3jFTSUcotzSnJLMipjE8CqlUy0DNQqo2tBQA
custom_model=%7B%22priority%22%3A%5B%7B%22if%22%3A%22road_class%3D%3DMOTORWAY%22%2C%22multiply_by%22%3A%220.0%22%7D%5D%7D
```


Note that the polyline encoding is used without additional compression as it does not seem to reduce the length further and also polyline encoding is nearly always more compact than generic compression. Furthermore flex polyline encoding seems to give 10-10% more compact results compared to standard polyline encoding. Also note that the flex polyline website says it is 'lossy' but this applies only for coordinates with higher than specified (1e-6) precision.

Also note that we use `CompressionStream` instead of an external library like lz-string or pako because it is often more compact for our use case and also keeps the dependency list small.

Minor: have also reduced the length a bit via using l=osm instead of layer=OpenStreetMap etc.

TODO: should be possible to disable the compression for e.g. debugging purposes via the settings?